### PR TITLE
Adding missing is isStopped() method for Android

### DIFF
--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -1,10 +1,8 @@
 package com.neuroidreactnativesdk
 
 import android.app.Application
-import com.facebook.react.bridge.Promise
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
+import android.util.Log
+import com.facebook.react.bridge.*
 import com.neuroid.tracker.NeuroID
 
 class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
@@ -20,15 +18,20 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun configure(key: String) {
         val activityCaller = reactApplicationCtx.currentActivity
-        val neuroID = NeuroID.Builder(application, key).build()
-        NeuroID.setNeuroIdInstance(neuroID)
+        if(NeuroID.getInstance() == null) {
+            val neuroID = NeuroID.Builder(application, key).build()
+            NeuroID.setNeuroIdInstance(neuroID)
+        }
+        NeuroID.getInstance()?.configureWithOptions(key, null)
     }
 
     @ReactMethod
-    fun configureWithOptions(key: String, endpoint: String) {
+    fun configureWithOptions(key: String, endpoint: String?) {
         val activityCaller = reactApplicationCtx.currentActivity
-        val neuroID = NeuroID.Builder(application, key).build()
-        NeuroID.setNeuroIdInstance(neuroID)
+        if(NeuroID.getInstance() == null) {
+            val neuroID = NeuroID.Builder(application, key).build()
+            NeuroID.setNeuroIdInstance(neuroID)
+        }
         NeuroID.getInstance()?.configureWithOptions(key, endpoint)
     }
 
@@ -98,4 +101,12 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         NeuroID.getInstance()?.setSiteId(siteId)
     }
 
+    @ReactMethod
+    fun isStopped(promise: Promise) {
+        val instance = NeuroID.getInstance()
+        if(instance == null)
+            promise.resolve(true)
+        else
+            promise.resolve(instance.isStopped())
+    }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,69 +17,76 @@ const NeuroidReactnativeSdk = NativeModules.NeuroidReactnativeSdk
       }
     );
 
-export function configure(apiKey: String): void {
-  NeuroidReactnativeSdk.configure(apiKey);
+export function configure(apiKey: String): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.configure(apiKey));
 }
 
 export function configureWithOptions(
   apiKey: String,
-  collectorEndPoint: String
-): void {
-  NeuroidReactnativeSdk.configure(apiKey, collectorEndPoint);
+  collectorEndPoint?: String
+): Promise<void> {
+  return Promise.resolve(
+    NeuroidReactnativeSdk.configure(apiKey, collectorEndPoint)
+  );
 }
+
 export function start(): Promise<Boolean> {
-  let promise: Promise<Boolean> = new Promise(function (resolve) {
+  return new Promise(async function (resolve) {
     try {
-      NeuroidReactnativeSdk.start();
+      await Promise.resolve(NeuroidReactnativeSdk.start());
       resolve(true);
     } catch (e) {
+      console.warn('Failed to start NID', e);
       resolve(false);
     }
   });
-  return promise;
 }
-export function stop(): Boolean {
-  try {
-    NeuroidReactnativeSdk.stop();
-    return true;
-  } catch (e) {
-    return false;
-  }
+export function stop(): Promise<Boolean> {
+  return new Promise(async function (resolve) {
+    try {
+      await Promise.resolve(NeuroidReactnativeSdk.stop());
+      resolve(true);
+    } catch (e) {
+      console.warn('Failed to stop NID', e);
+      resolve(false);
+    }
+  });
 }
-export function getSessionID(): Promise<String> | null {
-  return NeuroidReactnativeSdk.getSessionID();
+
+export function getSessionID(): Promise<String> {
+  return Promise.resolve(NeuroidReactnativeSdk.getSessionID());
 }
-export function setUserID(userID: String): Promise<void> | null {
-  return NeuroidReactnativeSdk.setUserID(userID);
+export function setUserID(userID: String): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.setUserID(userID));
 }
-export function excludeViewByTestID(
-  excludedView: String
-): Promise<void> | null {
-  return NeuroidReactnativeSdk.excludeViewByTestID(excludedView);
+export function excludeViewByTestID(excludedView: String): Promise<void> {
+  return Promise.resolve(
+    NeuroidReactnativeSdk.excludeViewByTestID(excludedView)
+  );
 }
 export function setEnvironmentProduction(value: Boolean) {
   // Pre-release
   console.log('NeuroID environment set: ', value);
-  NeuroidReactnativeSdk.setEnvironmentProduction(value);
+  return Promise.resolve(NeuroidReactnativeSdk.setEnvironmentProduction(value));
 }
 
-export function setSiteId(siteId: String) {
+export function setSiteId(siteId: String): Promise<void> {
   // Pre-release
   console.log('SiteID set ', siteId);
-  NeuroidReactnativeSdk.setSiteId(siteId);
+  return Promise.resolve(NeuroidReactnativeSdk.setSiteId(siteId));
 }
-export function setScreenName(screenName: String): Promise<void> | null {
-  return NeuroidReactnativeSdk.setScreenName(screenName);
+export function setScreenName(screenName: String): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.setScreenName(screenName));
 }
-export function formSubmit(): Promise<void> | null {
-  return NeuroidReactnativeSdk.formSubmit();
+export function formSubmit(): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.formSubmit());
 }
-export function formSubmitSuccess(): Promise<void> | null {
-  return NeuroidReactnativeSdk.formSubmitSuccess();
+export function formSubmitSuccess(): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.formSubmitSuccess());
 }
-export function formSubmitFailure(): Promise<void> | null {
-  return NeuroidReactnativeSdk.formSubmitFailure();
+export function formSubmitFailure(): Promise<void> {
+  return Promise.resolve(NeuroidReactnativeSdk.formSubmitFailure());
 }
-export function isStopped(): Promise<boolean> | null {
-  return NeuroidReactnativeSdk.isStopped();
+export function isStopped(): Promise<boolean> {
+  return Promise.resolve(NeuroidReactnativeSdk.isStopped());
 }


### PR DESCRIPTION
Improvement - TS issues with promises and null checks.
Bugfix - start and stop failures were not caught.
Bugfix - configure is always a NOOP because a NID instance always exists.


FYI this PR requires that https://github.com/Neuro-ID/neuroid-android-sdk/pull/97 be merged for a the new isStopped() method as well as the method signature change for configureWithOptions