### PR TITLE
ENG-5623-moving npm publish to a separate workflow

### DIFF
--- a/.github/workflows/github_actions_release_npm_version.yml
+++ b/.github/workflows/github_actions_release_npm_version.yml
@@ -1,71 +1,12 @@
-name: Publish to npm with updated package version
+name: Publish to npm
 
 on:
   workflow_dispatch:
-    inputs:
-      major-update:
-        description: Set `true` if there are breaking changes affecting sdk's across platforms i.e. react-native, android, ios etc.
-        required: false
-        type: boolean
-        default: false
-      minor-update:
-        description: Set `true` if there are multiple minor changes affecting sdk's across platforms i.e. react-native, android, ios etc.
-        required: false
-        type: boolean
-        default: false
-      patch-update:
-        description: Set `true` if the change affects only the react-native platform.
-        required: false
-        type: boolean
-        default: true
+    
 jobs:
-  update_version:
-    name: Update package version
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Main branch checkout
-        uses: actions/checkout@v3
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Determine update type
-        run: |
-          if [ ${{ inputs.major-update }} == "true" ]; then 
-            echo "RELEASE_TYPE=major" >> $GITHUB_ENV
-          elif [ ${{ inputs.minor-update }} == "true" ]; then 
-            echo "RELEASE_TYPE=minor" >> $GITHUB_ENV
-          else 
-            echo "RELEASE_TYPE=patch" >> $GITHUB_ENV
-          fi
-
-      - name: Update version
-        run: |
-          git config --global user.email developer@neuro-id.com
-          git config --global user.name neuroid-developer
-          npm version ${{ env.RELEASE_TYPE }}
-          git push origin
-  
-  create_tag:
-    name: Create tag
-    runs-on: ubuntu-latest
-    needs: [update_version]
-    steps:
-      - name: Read package version
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
-
-      - name: Update tag
-        run: |
-          git tag -a ${{ env.PACKAGE_VERSION }} -m "Release version ${{ env.PACKAGE_VERSION }}"
-          git push origin ${{ env.PACKAGE_VERSION }}
-
   publish_npm_package:
     name: Publish npm package
-    runs-on: ubuntu-latest
-    needs: [create_tag]
+    runs-on: [self-hosted, group-default]
     steps:
       - name: Publish to npm
         run: npm publish --tag latest --dry-run

--- a/.github/workflows/github_actions_update_npm_version.yml
+++ b/.github/workflows/github_actions_update_npm_version.yml
@@ -1,0 +1,60 @@
+name: Updates package version and creates a PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      major-update:
+        description: Set `true` if there are breaking changes affecting sdk's across platforms i.e. react-native, android, ios etc.
+        required: false
+        type: boolean
+        default: false
+      minor-update:
+        description: Set `true` if there are multiple minor changes affecting sdk's across platforms i.e. react-native, android, ios etc.
+        required: false
+        type: boolean
+        default: false
+      patch-update:
+        description: Set `true` if the change affects only the react-native platform.
+        required: false
+        type: boolean
+        default: true
+jobs:
+  update_version:
+    name: Update package version
+    runs-on: [self-hosted, group-default]
+    steps:
+      - name: Determine update type
+        run: |
+          if [ ${{ inputs.major-update }} == "true" ]; then 
+            echo "RELEASE_TYPE=major" >> $GITHUB_ENV
+          elif [ ${{ inputs.minor-update }} == "true" ]; then 
+            echo "RELEASE_TYPE=minor" >> $GITHUB_ENV
+          else 
+            echo "RELEASE_TYPE=patch" >> $GITHUB_ENV
+          fi
+
+      - name: Main branch checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update version
+        run: |
+          git config --global user.email developer@neuro-id.com
+          git config --global user.name neuroid-developer
+          npm version ${{ env.RELEASE_TYPE }}
+
+      - name: Read package version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "BRANCH_NAME=${PACKAGE_VERSION}_version_update" >> $GITHUB_ENV
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: update package version to ${PACKAGE_VERSION}
+          title: Update version
+          branch: ${{ env.BRANCH_NAME }}
+
+

--- a/.github/workflows/github_actions_update_npm_version.yml
+++ b/.github/workflows/github_actions_update_npm_version.yml
@@ -1,4 +1,4 @@
-name: Updates package version and creates a PR
+name: Updates npm package version and creates a PR
 
 on:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroid-reactnative-sdk",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Neuro-ID React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Creating a 2 step workflow to release an npm package. 
The first workflow will take in the input of whether the update is major/minor/patch. This will then update the package version in the package.json file and create a PR. 
The next workflow can be started after the PR from step 1 has been merged. This publishes the updated  npm package.