### PR TITLE
ENG-6172-adding tags to point to Dev and Released Github states

### DIFF
--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -31,8 +31,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: yarn
-
       - name: Publish to npm
         run: npm publish --tag latest
         env:
@@ -44,29 +42,11 @@ jobs:
           echo "PACKAGE_VERSION=v${PACKAGE_VERSION}" >> $GITHUB_ENV
       
       - name: Create release
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const name = 'Release Version: ${{ env.PACKAGE_VERSION }}';
-            const body = 'SDK Version ${{ env.PACKAGE_VERSION }}';
-            const createRelease = async () => {
-                await github.rest.repos.createRelease({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    tag_name: 'v${{ env.PACKAGE_VERSION }}',
-                    name: name,
-                    body: body,
-                    draft: false,
-                    prerelease: false,
-                    generate_release_notes: true
-                });
-                console.log(`Release created`);
-            }
-            createRelease();
-      - name: Create Latest Tag
         run: |
-            git tag latest
-            git push origin latest
+          gh release create ${{ env.PACKAGE_VERSION }} --generate-notes --latest --title "${{ env.PACKAGE_VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   triggerRNSandboxProd:
     name: Trigger React Native Prod Sandbox release
     runs-on: ubuntu-latest

--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -46,7 +46,11 @@ jobs:
           gh release create ${{ env.PACKAGE_VERSION }} --generate-notes --latest --title "${{ env.PACKAGE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      - name: Create latest Tag
+        run: |
+            git tag latest
+            git push -f origin latest
   triggerRNSandboxProd:
     name: Trigger React Native Prod Sandbox release
     runs-on: ubuntu-latest

--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -47,10 +47,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Create latest Tag
+      - name: Update new commit to have "Latest" Tag
         run: |
+            git config --global user.email developer@neuro-id.com
+            git config --global user.name neuroid-developer
+            set +e
+            git push origin :latest
+            git tag -d latest
             git tag latest
-            git push -f origin latest
+            git push origin latest
+            set -e
   triggerRNSandboxProd:
     name: Trigger React Native Prod Sandbox release
     runs-on: ubuntu-latest

--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -63,6 +63,10 @@ jobs:
                 console.log(`Release created`);
             }
             createRelease();
+      - name: Create Latest Tag
+        run: |
+            git tag latest
+            git push origin latest
   triggerRNSandboxProd:
     name: Trigger React Native Prod Sandbox release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-android-sdk-dev.yml
+++ b/.github/workflows/update-android-sdk-dev.yml
@@ -3,50 +3,29 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [publish-dev-android]
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
-  refreshDependencies:
-    name: Pull recent Android SDK master build
+  createTag:
+    name: Create Development tag
     runs-on: ubuntu-latest
 
     steps:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-
-      - name: Cache Gradle and wrapper
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Grant Permission for Gradlew to Execute
-        run: chmod +x gradlew
-
-      - name: Refresh dependencies
-        run: ./gradlew :app:assemble --refresh-dependencies
-      
       - name: Create Development Tag
         run: |
             git tag development
-            git push origin development
+            git push -f origin development
   triggerRNSandboxAndroidDev:
     name: Trigger React Native Dev Sandbox release
     runs-on: ubuntu-latest
-    needs: refreshDependencies
+    needs: createTag
     steps:
       - name: Trigger ReactNative Sandbox Dev Deployment
         run: |

--- a/.github/workflows/update-android-sdk-dev.yml
+++ b/.github/workflows/update-android-sdk-dev.yml
@@ -38,7 +38,11 @@ jobs:
 
       - name: Refresh dependencies
         run: ./gradlew :app:assemble --refresh-dependencies
-  
+      
+      - name: Create Development Tag
+        run: |
+            git tag development
+            git push origin development
   triggerRNSandboxAndroidDev:
     name: Trigger React Native Dev Sandbox release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-android-sdk-dev.yml
+++ b/.github/workflows/update-android-sdk-dev.yml
@@ -18,10 +18,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Create Development Tag
+      - name: Update new commit to have "Development" Tag
         run: |
-            git tag development
-            git push -f origin development
+          git config --global user.email developer@neuro-id.com
+          git config --global user.name neuroid-developer
+          set +e
+          git push origin :development
+          git tag -d development
+          git tag development
+          git push origin development
+          set -e
+
   triggerRNSandboxAndroidDev:
     name: Trigger React Native Dev Sandbox release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Creating 'development' tag when PR's are merged to main and on Android SDK updates. 
On Prod release 'latest' tag is created.
Removing refreshing android libs from here to the Sandbox repo.