### PR TITLE
ENG-6207 - Expose Target Registration Method

### DIFF
--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -110,4 +110,14 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         else
             promise.resolve(instance.isStopped())
     }
+
+    @ReactMethod
+    fun registerPageTargets(promise: Promise){
+        val reactCurrentActivity = currentActivity
+        if (reactCurrentActivity != null) {
+            NeuroID.getInstance()?.setForceStart(reactCurrentActivity)
+        }
+
+          promise.resolve(true)
+    }
 }

--- a/ios/NeuroidReactnativeSdk.m
+++ b/ios/NeuroidReactnativeSdk.m
@@ -38,4 +38,7 @@ RCT_EXTERN_METHOD(excludeViewByTestID:(NSString)excludedView
 RCT_EXTERN_METHOD(setScreenName:(NSString)screenName
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(registerPageTargets: (RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
 @end

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -63,4 +63,10 @@ class NeuroidReactnativeSdk: NSObject {
         try? NeuroID.setScreenName(screen: screenName)
         resolve(true)
     }
+
+    @objc(registerPageTargets:withRejecter:)
+    func registerPageTargets(resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
+        resolve(true)
+    }
+
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,6 +88,9 @@ export const NeuroID: NeuroIDClass = {
   isStopped: function isStopped(): Promise<boolean> {
     return Promise.resolve(NeuroidReactnativeSdk.isStopped());
   },
+  registerPageTargets: function isStopped(): Promise<void> {
+    return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
+  },
 };
 
 export default NeuroID;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,4 +10,5 @@ export interface NeuroIDClass {
   setSiteId: (siteId: String) => Promise<void>;
   setScreenName: (screenName: String) => Promise<void>;
   isStopped: () => Promise<boolean>;
+  registerPageTargets: () => Promise<void>;
 }


### PR DESCRIPTION
Because RN doesn't use native Android Lifecycle methods where we normally register targets, we are exposing a method that customers will need to call on every page they want to track targets on. Better solution TBD