### PR TITLE
ENG-6334-removing typescript

### DIFF
--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -39,12 +39,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
-      - name: Publish to npm type script
-        run: npm publish --tag latest
-        working-directory: neuroid-reactnative-sdk-types/
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-
       - name: Retrieve package version
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
Removing typescript package publish because of privacy scope in NPM registry.