### PR TITLE
Eng 6373 add option to config

### DIFF
--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -2,6 +2,7 @@ package com.neuroidreactnativesdk
 
 import android.app.Application
 import com.facebook.react.bridge.*
+import com.facebook.react.bridge.ReadableMap
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.extensions.setVerifyIntegrationHealth
 
@@ -32,7 +33,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun configure(key: String, options: Map<String, Any> = mapOf()) {
+    fun configure(key: String, options: ReadableMap) {
         if (NeuroID.getInstance() == null) {
             val neuroID = NeuroID.Builder(application, key).build()
             NeuroID.setNeuroIdInstance(neuroID)

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -32,7 +32,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun configure(key: String) {
+    fun configure(key: String, options: Map<String, Any> = mapOf()) {
         if (NeuroID.getInstance() == null) {
             val neuroID = NeuroID.Builder(application, key).build()
             NeuroID.setNeuroIdInstance(neuroID)


### PR DESCRIPTION
Add readable map parameter to configure() method signature to read the options in. Not doing anything with the options in Android at this time however it needs to be there in the method signature since iOS is using this. Tested and working on Android 21 simulator: 
<img width="369" alt="image" src="https://github.com/Neuro-ID/neuroid-reactnative-sdk/assets/139158682/1771365e-b4a7-4086-8a5b-5a23122e17b0">
