### PR TITLE
ENG-6277 - Add script to create ADV package

### DIFF
--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -12,8 +12,8 @@ on:
       - main
 
 permissions:
-    contents: write
-    issues: write
+  contents: write
+  issues: write
 
 jobs:
   createRelease:
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
-      
+
       - run: npm ci
 
       - name: Publish to npm
@@ -42,23 +42,30 @@ jobs:
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           echo "PACKAGE_VERSION=v${PACKAGE_VERSION}" >> $GITHUB_ENV
-      
+
       - name: Create release
         run: |
           gh release create ${{ env.PACKAGE_VERSION }} --generate-notes --latest --title "${{ env.PACKAGE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Update new commit to have "Latest" Tag
         run: |
-            git config --global user.email developer@neuro-id.com
-            git config --global user.name neuroid-developer
-            set +e
-            git push origin :latest
-            git tag -d latest
-            git tag latest
-            git push origin latest
-            set -e
+          git config --global user.email developer@neuro-id.com
+          git config --global user.name neuroid-developer
+          set +e
+          git push origin :latest
+          git tag -d latest
+          git tag latest
+          git push origin latest
+          set -e
+
+      - name: Create ADV Package & Publish to npm
+        run: |
+          npm run setupAdvancedDevice
+          npm publish --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
   triggerRNSandboxProd:
     name: Trigger React Native Prod Sandbox release
     runs-on: ubuntu-latest
@@ -72,7 +79,7 @@ jobs:
              -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
              https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
              -d '{"event_type":"publish-prod-android","client_payload":{"version":"${{env.PACKAGE_VERSION}}", "message": "${{ github.event.commit.message }}"}}'
-      
+
       - name: Trigger ReactNative Sandbox iOS Deployment
         run: |
           curl \
@@ -89,10 +96,10 @@ jobs:
         if: ${{ needs.triggerRNSandboxProd.result == 'failure' }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_CHANNEL:  ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
+          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed to trigger React Native Sandbox release (Prod)"
+          SLACK_MESSAGE: 'Failed to trigger React Native Sandbox release (Prod)'
           SLACK_TITLE: Failed to trigger React Native Sandbox release (Prod)
           SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,7 @@ dependencies {
 
   implementation 'androidx.core:core-ktx:1.6.0'
   releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.0.4'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.0.4'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.0.4'
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -48,7 +48,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     
     @ReactMethod
     fun start() {
-         NeuroID.getInstance()?.setIsRN()
+        NeuroID.getInstance()?.setIsRN()
         NeuroID.getInstance()?.start()
     }
 

--- a/neuroid-reactnative-sdk.podspec
+++ b/neuroid-reactnative-sdk.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/Neuro-ID/neuroid-reactnative-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "prepare": "bob build",
     "release": "release-it",
     "postinstall": "patch-package",
-    "bootstrap": "yarn"
+    "bootstrap": "yarn",
+    "setupAdvancedDevice": "bash ./scripts/advancedDeviceSetup.sh"
   },
   "keywords": [
     "react-native",

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -27,7 +27,7 @@ RCT_EXTERN_METHOD(start: \
 # Add to ios function file
 sed -i '' '/@objc(start:withRejecter:)/i \
     @objc(start:advancedDeviceSignals:withResolver:withRejecter:) \
-    func configure(advancedDeviceSignals: Bool, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void { \
+    func start(advancedDeviceSignals: Bool, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void { \
         NeuroID.setIsRN() \
         NeuroID.start(advancedDeviceSignals: advancedDeviceSignals) \
         resolve(true) \
@@ -43,6 +43,7 @@ import com.neuroid.tracker.extensions.start\
 
 sed -i '' '/fun start() {/i \
     fun start(advancedDeviceSignals: Boolean) {\
+        NeuroID.getInstance()?.setIsRN() \
         NeuroID.getInstance()?.start(advancedDeviceSignals)\
     }\
 \
@@ -55,13 +56,7 @@ sed -i '' 's/start: ()/start: (advancedDeviceSignals?: Boolean)/' src/types.ts
 
 # update index
 sed -i '' 's/start(): /start(advancedDeviceSignals?: Boolean): /' src/index.tsx
-sed -i '' '/await Promise.resolve(NeuroidReactnativeSdk.start());/i \
-        if(advancedDeviceSignals){ \
-          await Promise.resolve(NeuroidReactnativeSdk.start(advancedDeviceSignals)); \
-        } else { \
- ' src/index.tsx
- sed -i '' 's/await Promise.resolve(NeuroidReactnativeSdk.start());/ await Promise.resolve(NeuroidReactnativeSdk.start());\n        }/' src/index.tsx
-
+sed -i '' 's/NeuroidReactnativeSdk.start()/NeuroidReactnativeSdk.start(!!advancedDeviceSignals)/' src/index.tsx
 
 # update package.json for new module name and description
 sed -i '' 's/"name": "neuroid-reactnative-sdk"/"name": "neuroid-reactnative-sdk-advanced-device"/' package.json

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -28,6 +28,7 @@ RCT_EXTERN_METHOD(start: \
 sed -i '' '/@objc(start:withRejecter:)/i \
     @objc(start:advancedDeviceSignals:withResolver:withRejecter:) \
     func configure(advancedDeviceSignals: Bool, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void { \
+        NeuroID.setIsRN() \
         NeuroID.start(advancedDeviceSignals: advancedDeviceSignals) \
         resolve(true) \
     } \

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+echo "Updating Libraries"
+
+# Update iOS Podfile to use NeuroID/Advanced 
+version=$(sed -n "s/.*'NeuroID', '\([^']*\)'.*/\1/p" neuroid-reactnative-sdk.podspec)
+
+if [ -n "$version" ]; then
+    sed -i '' 's/s.dependency "React-Core"/s.dependency "NeuroID\/AdvancedDevice", '"'$version'"' \n  s.dependency "React-Core"/' neuroid-reactnative-sdk.podspec
+else
+    sed -i '' 's/s.dependency "React-Core"/s.dependency "NeuroID\/AdvancedDevice" \n  s.dependency "React-Core"/' neuroid-reactnative-sdk.podspec
+fi
+
+# Update Android Libraries 
+sed -i '' 's/neuroid-android-sdk:react-android-sdk/neuroid-android-sdk:react-android-advanced-device-sdk/' android/build.gradle
+
+# Implement code for iOS header and actual
+# # Add to ios header
+sed -i '' '/start:/i \
+RCT_EXTERN_METHOD(start: \
+                parameters:(BOOL *)advancedDeviceSignals \
+                withResolver: (RCTPromiseResolveBlock)resolve \
+                withRejecter:(RCTPromiseRejectBlock)reject) \
+\
+' ios/NeuroidReactnativeSdk.m
+
+# Add to ios function file
+sed -i '' '/@objc(start:withRejecter:)/i \
+    @objc(start:advancedDeviceSignals:withResolver:withRejecter:) \
+    func configure(advancedDeviceSignals: Bool, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void { \
+        NeuroID.start(advancedDeviceSignals: advancedDeviceSignals) \
+        resolve(true) \
+    } \
+\
+' ios/NeuroidReactnativeSdk.swift
+
+
+# Implement code for Android actual 
+sed -i '' '/import com.neuroid.tracker.extensions.setVerifyIntegrationHealth/i \
+import com.neuroid.tracker.extensions.start\
+' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+
+sed -i '' '/fun start() {/i \
+    fun start(advancedDeviceSignals: Boolean) {\
+        NeuroID.getInstance()?.start(advancedDeviceSignals)\
+    }\
+\
+    @ReactMethod\
+' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+
+
+# update types
+sed -i '' 's/start: ()/start: (advancedDeviceSignals?: Boolean)/' src/types.ts
+
+# update index
+sed -i '' 's/start(): /start(advancedDeviceSignals?: Boolean): /' src/index.tsx
+sed -i '' '/await Promise.resolve(NeuroidReactnativeSdk.start());/i \
+        if(advancedDeviceSignals){ \
+          await Promise.resolve(NeuroidReactnativeSdk.start(advancedDeviceSignals)); \
+        } else { \
+ ' src/index.tsx
+ sed -i '' 's/await Promise.resolve(NeuroidReactnativeSdk.start());/ await Promise.resolve(NeuroidReactnativeSdk.start());\n        }/' src/index.tsx
+
+
+# update package.json for new module name and description
+sed -i '' 's/"name": "neuroid-reactnative-sdk"/"name": "neuroid-reactnative-sdk-advanced-device"/' package.json
+sed -i '' 's/"description": "Official NeuroID React Native SDK"/"description": "Official NeuroID React Native SDK for Advanced Device Tracking"/' package.json

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -15,25 +15,12 @@ fi
 sed -i '' 's/neuroid-android-sdk:react-android-sdk/neuroid-android-sdk:react-android-advanced-device-sdk/' android/build.gradle
 
 # Implement code for iOS header and actual
-# # Add to ios header
-sed -i '' '/start:/i \
-RCT_EXTERN_METHOD(start: \
-                parameters:(BOOL *)advancedDeviceSignals \
-                withResolver: (RCTPromiseResolveBlock)resolve \
-                withRejecter:(RCTPromiseRejectBlock)reject) \
-\
-' ios/NeuroidReactnativeSdk.m
+sed -i '' 's/start:/start:(BOOL)advancedDeviceSignals\n                 withResolver:/' ios/NeuroidReactnativeSdk.m
 
 # Add to ios function file
-sed -i '' '/@objc(start:withRejecter:)/i \
-    @objc(start:advancedDeviceSignals:withResolver:withRejecter:) \
-    func start(advancedDeviceSignals: Bool, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void { \
-        NeuroID.setIsRN() \
-        NeuroID.start(advancedDeviceSignals: advancedDeviceSignals) \
-        resolve(true) \
-    } \
-\
-' ios/NeuroidReactnativeSdk.swift
+sed -i '' 's/@objc(start:withRejecter:)/@objc(start:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
+sed -i '' 's/func start(resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {/func start(advancedDeviceSignals: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {/' ios/NeuroidReactnativeSdk.swift
+sed -i '' 's/NeuroID.start()/NeuroID.start(advancedDeviceSignals: advancedDeviceSignals)/' ios/NeuroidReactnativeSdk.swift
 
 
 # Implement code for Android actual 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,7 @@ export const NeuroID: NeuroIDClass = {
   isStopped: function isStopped(): Promise<boolean> {
     return Promise.resolve(NeuroidReactnativeSdk.isStopped());
   },
-  registerPageTargets: function isStopped(): Promise<void> {
+  registerPageTargets: function registerPageTargets(): Promise<void> {
     if (Platform.OS === 'ios') {
       if (!usingRNNavigation) {
         return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());


### PR DESCRIPTION
This PR includes a script (`advancedDeviceSetup.sh`) that will be run on the npm publish workflow. The script will edit all the applicable files to include the ADV work done in the native SDK's. Then publish to a new NPM package called `neuroid-reactnative-sdk-advanced-device` which a customer can install instead of our traditional `neuroid-reactnative-sdk`