### PR TITLE
ENG-7422 - Start session fix & ENG-7454 - Stop Fix

### DIFF
--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -139,12 +139,17 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun stop(promise: Promise) {
-        val stopped = NeuroID.getInstance()?.stop()
+        try {
+            val stopped = NeuroID.getInstance()?.stop()
 
-        if (stopped != null) {
-            promise.resolve(stopped)
-        } else {
-            promise.resolve(false)
+            if (stopped != null) {
+                promise.resolve(stopped)
+            } else {
+                promise.resolve(false)
+            }
+        } catch (e: Exception) {
+            println("NEUROID EXCEPTION $e")
+            promise.resolve(NeuroID.getInstance()?.isStopped())
         }
     }
 

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -2,13 +2,13 @@ package com.neuroidreactnativesdk
 
 import android.app.Application
 import com.facebook.react.bridge.*
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.extensions.setVerifyIntegrationHealth
-import com.facebook.react.bridge.Arguments
 
 class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext) {
+        ReactContextBaseJavaModule(reactContext) {
 
     companion object {
         @JvmStatic
@@ -55,12 +55,12 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun getClientID(promise: Promise){
+    fun getClientID(promise: Promise) {
         promise.resolve(NeuroID.getInstance()?.getClientID())
     }
 
     @ReactMethod
-    fun getEnvironment(promise: Promise){
+    fun getEnvironment(promise: Promise) {
         promise.resolve(NeuroID.getInstance()?.getEnvironment())
     }
 
@@ -87,17 +87,14 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun isStopped(promise: Promise) {
         val instance = NeuroID.getInstance()
-        if (instance == null)
-            promise.resolve(true)
-        else
-            promise.resolve(instance.isStopped())
+        if (instance == null) promise.resolve(true) else promise.resolve(instance.isStopped())
     }
 
     @ReactMethod
     fun setScreenName(screen: String, promise: Promise) {
         val result = NeuroID.getInstance()?.setScreenName(screen)
 
-        if (result != null){
+        if (result != null) {
             promise.resolve(result)
         } else {
             promise.resolve(false)
@@ -113,31 +110,27 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun setUserID(id: String, promise: Promise) {
         var result = NeuroID.getInstance()?.setUserID(id)
-        result?.let {
-            promise.resolve(it)
-        }
+        result?.let { promise.resolve(it) }
         promise.resolve(false)
     }
 
     @ReactMethod
-    fun setRegisteredUserID(id: String, promise: Promise)  {
+    fun setRegisteredUserID(id: String, promise: Promise) {
         var result = NeuroID.getInstance()?.setRegisteredUserID(id)
-        result?.let {
-            promise.resolve(it)
-        }
+        result?.let { promise.resolve(it) }
         promise.resolve(false)
     }
 
     @ReactMethod
     fun setVerifyIntegrationHealth(enable: Boolean) {
-        NeuroID.getInstance()?.setVerifyIntegrationHealth(enable)       
+        NeuroID.getInstance()?.setVerifyIntegrationHealth(enable)
     }
 
     @ReactMethod
     fun start(promise: Promise) {
-        val started = NeuroID.getInstance()?.start();
+        val started = NeuroID.getInstance()?.start()
 
-        if (started != null){
+        if (started != null) {
             promise.resolve(started)
         } else {
             promise.resolve(false)
@@ -148,7 +141,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     fun stop(promise: Promise) {
         val stopped = NeuroID.getInstance()?.stop()
 
-        if (stopped != null){
+        if (stopped != null) {
             promise.resolve(stopped)
         } else {
             promise.resolve(false)
@@ -156,7 +149,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun registerPageTargets(promise: Promise){
+    fun registerPageTargets(promise: Promise) {
         val reactCurrentActivity = currentActivity
         if (reactCurrentActivity != null) {
             NeuroID.getInstance()?.registerPageTargets(reactCurrentActivity)
@@ -166,7 +159,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun startSession(sessionID: String, promise: Promise) {
+    fun startSession(sessionID: String? = null, promise: Promise) {
         val result = NeuroID.getInstance()?.startSession(sessionID)
         val resultData = Arguments.createMap()
         result?.let {
@@ -176,7 +169,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         promise.resolve(resultData)
     }
 
-     @ReactMethod
+    @ReactMethod
     fun stopSession(promise: Promise) {
         val result = NeuroID.getInstance()?.stopSession()
         promise.resolve(result)

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -2,8 +2,6 @@ package com.neuroidreactnativesdk
 
 import android.app.Application
 import com.facebook.react.bridge.*
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.ReadableMap
 import com.neuroid.tracker.NeuroID
 import com.neuroid.tracker.extensions.setVerifyIntegrationHealth
 

--- a/neuroid-reactnative-sdk-types/src/types.d.ts
+++ b/neuroid-reactnative-sdk-types/src/types.d.ts
@@ -20,7 +20,7 @@ export interface NeuroIDClass {
     stop: () => Promise<Boolean>;
     registerPageTargets: () => Promise<void>;
     setupPage: (screenName: string) => Promise<void>;
-    startSession: (sessionID: string) => Promise<SessionStartResult>;
+    startSession: (sessionID?: string) => Promise<SessionStartResult>;
     stopSession: () => Promise<boolean>;
     resumeCollection: () => Promise<void>;
     pauseCollection: () => Promise<void>;

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -49,8 +49,8 @@ sed -i='' '/fun start(promise: Promise) {/i \
     @ReactMethod\
 ' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
 
-sed -i='' '/fun startSession(sessionID: String, promise: Promise) {/i \
-    fun startSession(sessionID: String, advancedDeviceSignals: Boolean, promise: Promise) {\
+sed -i='' '/fun startSession(sessionID: String? = null, promise: Promise) {/i \
+    fun startSession(sessionID: String? = null, advancedDeviceSignals: Boolean, promise: Promise) {\
         val result = NeuroID.getInstance()?.startSession(sessionID, advancedDeviceSignals) \
         val resultData = Arguments.createMap() \
         result?.let { \
@@ -66,12 +66,12 @@ sed -i='' '/fun startSession(sessionID: String, promise: Promise) {/i \
 
 # update types
 sed -i='' 's/start: ()/start: (advancedDeviceSignals?: Boolean)/' src/types.ts
-sed -i='' 's/startSession: (sessionID: string)/startSession: (\n    sessionID: string,\n    advancedDeviceSignals?: Boolean\n  )/' src/types.ts
+sed -i='' 's/startSession: (sessionID?: string)/startSession: (\n    sessionID?: string,\n    advancedDeviceSignals?: Boolean\n  )/' src/types.ts
 
 # update index
 sed -i='' 's/start(): /start(advancedDeviceSignals?: Boolean): /' src/index.tsx
 sed -i='' 's/NeuroidReactnativeSdk.start()/\n          NeuroidReactnativeSdk.start(!!advancedDeviceSignals)\n        /' src/index.tsx
-sed -i='' 's/sessionID: string/sessionID: string,\n    advancedDeviceSignals?: Boolean/' src/index.tsx
+sed -i='' 's/sessionID?: string/sessionID?: string,\n    advancedDeviceSignals?: Boolean/' src/index.tsx
 sed -i='' 's/NeuroidReactnativeSdk.startSession(sessionID)/NeuroidReactnativeSdk.startSession(\n      sessionID,\n      !!advancedDeviceSignals\n    )/' src/index.tsx
 
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,7 +209,7 @@ export const NeuroID: NeuroIDClass = {
   },
 
   startSession: async function startSession(
-    sessionID: string
+    sessionID?: string
   ): Promise<SessionStartResult> {
     const result = await NeuroidReactnativeSdk.startSession(sessionID);
     NeuroIDLog.d(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,7 +183,7 @@ export const NeuroID: NeuroIDClass = {
       try {
         const result = await Promise.resolve(NeuroidReactnativeSdk.stop());
         resolve(result);
-        NeuroIDLog.d('NeuroID Stopped');
+        NeuroIDLog.d('NeuroID Stopped: ', result);
       } catch (e: any) {
         NeuroIDLog.e('Failed to stop NID', e);
         resolve(false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface NeuroIDClass {
 
   registerPageTargets: () => Promise<void>;
   setupPage: (screenName: string) => Promise<void>;
-  startSession: (sessionID: string) => Promise<SessionStartResult>;
+  startSession: (sessionID?: string) => Promise<SessionStartResult>;
   stopSession: () => Promise<boolean>;
   resumeCollection: () => Promise<void>;
   pauseCollection: () => Promise<void>;


### PR DESCRIPTION
ENG-7422 - calling startSession() is now allowed (previously required a sessionID to be passed)

ENG-7454 - calling .stop() will catch any errors thrown from native platforms. Android SDK will also be updated to return a boolean value instead of Kotlin.Unit