### PR TITLE
ENG-7722-dev-workflow-trigger-fixes

### DIFF
--- a/.github/workflows/update-android-sdk-dev.yml
+++ b/.github/workflows/update-android-sdk-dev.yml
@@ -13,16 +13,16 @@ jobs:
   triggerDevSandbox:
     name: Trigger ReactNative Sandbox Dev Deployment
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged && !startsWith(github.head_ref, 'releases/')
+    if: !github.head_ref.startswith('releases/'):
     steps:
-      - name: Trigger ReactNative Sandbox Dev 
+      - name: Trigger ReactNative Sandbox Dev
         run: |
-         curl \
-             -X POST \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
-             https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
-             -d '{"event_type":"publish-dev-android","client_payload":{"version":"master-SNAPSHOT", "message": "Android sdk master-SNAPSHOT"}}'
+          curl \
+              -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
+              https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
+              -d '{"event_type":"publish-dev-android","client_payload":{"version":"master-SNAPSHOT", "message": "Android sdk master-SNAPSHOT"}}'
 
       - name: Send Slack Notification on Failure
         if: failure()
@@ -31,7 +31,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed to trigger React Native Android Sandbox release (Dev)"
+          SLACK_MESSAGE: 'Failed to trigger React Native Android Sandbox release (Dev)'
           SLACK_TITLE: Failed to trigger React Native Android Sandbox release (Dev)
           SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/.github/workflows/update-ios-sdk-dev.yml
+++ b/.github/workflows/update-ios-sdk-dev.yml
@@ -3,7 +3,7 @@ name: Update Dev React Native iOS SDK
 on:
   workflow_dispatch:
   repository_dispatch:
-        types: [on-demand-testflight]
+    types: [on-demand-testflight-dev]
   pull_request_target:
     types:
       - closed
@@ -12,31 +12,31 @@ on:
 
 jobs:
   createTag:
-    if: github.event.pull_request.merged && !startsWith(github.head_ref, 'releases/')
+    if: !github.head_ref.startswith('releases/'):
     runs-on: ubuntu-latest
     steps:
       - name: Main branch Checkout
         uses: actions/checkout@v3
-         
+
       - name: Update new commit to have "Development" Tag
         run: |
-           git config --global user.email developer@neuro-id.com
-           git config --global user.name neuroid-developer
-           set +e
-           git push origin :development
-           git tag -d development
-           git tag development
-           git push origin development
-           set -e
+          git config --global user.email developer@neuro-id.com
+          git config --global user.name neuroid-developer
+          set +e
+          git push origin :development
+          git tag -d development
+          git tag development
+          git push origin development
+          set -e
 
       - name: Run ReactNative Sandbox iOS Dev Deployment
         run: |
-            curl \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
-            https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
-            -d '{"event_type":"on-demand-testflight-dev","client_payload":{"version":"development", "message": "iOS development tag"}}'
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
+          https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
+          -d '{"event_type":"on-demand-testflight-dev","client_payload":{"version":"development", "message": "iOS development tag"}}'
 
       - name: Send Slack Notification on Failure
         if: failure()
@@ -45,7 +45,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed to trigger React Native iOS Sandbox release (Dev)"
+          SLACK_MESSAGE: 'Failed to trigger React Native iOS Sandbox release (Dev)'
           SLACK_TITLE: Failed to trigger React Native iOS Sandbox release (Dev)
           SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}


### PR DESCRIPTION
Matching dev repository_dispatch workflow name with ios deploy trigger. 
Remove deploy only on merge constraint as this should also deploy with the repository_dispatch trigger