### PR TITLE
ENG-7722-retain master build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,8 +130,11 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.1.1'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.1.1'
+
+  // Always leave this pointing to master build 
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:master-SNAPSHOT'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:master-SNAPSHOT'
+
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")


### PR DESCRIPTION
Pointing sdk development tag to the android sdk master build.