### PR TITLE
 ENG-8174/Pin android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.2'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.2'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.1'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.1'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:master-SNAPSHOT'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:master-SNAPSHOT'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.2'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.2'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.1'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.1'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.2'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.2'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -118,9 +118,11 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun attemptedLogin(id: String, promise: Promise) {
-        var result = NeuroID.getInstance()?.attemptedLogin(id)
-        result?.let { promise.resolve(it) }
-        promise.resolve(false)
+        // TODO
+        // Attempted Login is temporarily disabled until we have a new release for react native
+        // var result = NeuroID.getInstance()?.attemptedLogin(id)
+        // result?.let { promise.resolve(it) }
+        // promise.resolve(false)
     }
 
     @ReactMethod

--- a/neuroid-reactnative-sdk.podspec
+++ b/neuroid-reactnative-sdk.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
- s.dependency 'NeuroID', '3.2.0'
+  s.dependency 'NeuroID', '3.2.0'
   s.dependency "React-Core" 
 end


### PR DESCRIPTION
React native is currently building off off master development branches of android which contains breaking changes not yet released for NeuroID React Native SDK. This PR pins android release to v3.2.2 (last non breaking update) in order for us to merge depedabot updates.

Eventually, we will releasee changes to React Native to support latest SDKs.

In addition, disabling AttemptedLogin within Android as this has not been released yet for Android.