### PR TITLE
ENG-7827 add multiflow methods startAppFlow()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.2.2'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.2.2'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.3.0'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.3.0'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:v3.3.0'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:v3.3.0'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-advanced-device-sdk:master-SNAPSHOT'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-advanced-device-sdk-debug:master-SNAPSHOT'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-advanced-device-sdk:master-SNAPSHOT'
-  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-advanced-device-sdk-debug:master-SNAPSHOT'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:master-SNAPSHOT'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:master-SNAPSHOT'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -117,7 +117,7 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun attemptedLogin(id: String, promise: Promise) {
+    fun attemptedLogin(id: String?, promise: Promise) {
         var result = NeuroID.getInstance()?.attemptedLogin(id)
         result?.let { promise.resolve(it) }
         promise.resolve(false)

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -130,12 +130,12 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun start(promise: Promise) {
-        val started = NeuroID.getInstance()?.start()
-
-        if (started != null) {
-            promise.resolve(started)
-        } else {
-            promise.resolve(false)
+        NeuroID.getInstance()?.start() {
+            if (it != null) {
+                promise.resolve(it)
+            } else {
+                promise.resolve(false)
+            }
         }
     }
 

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -118,11 +118,9 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun attemptedLogin(id: String, promise: Promise) {
-        // TODO
-        // Attempted Login is temporarily disabled until we have a new release for react native
-        // var result = NeuroID.getInstance()?.attemptedLogin(id)
-        // result?.let { promise.resolve(it) }
-        // promise.resolve(false)
+        var result = NeuroID.getInstance()?.attemptedLogin(id)
+        result?.let { promise.resolve(it) }
+        promise.resolve(false)
     }
 
     @ReactMethod
@@ -163,19 +161,17 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         if (reactCurrentActivity != null) {
             NeuroID.getInstance()?.registerPageTargets(reactCurrentActivity)
         }
-
         promise.resolve(true)
     }
 
     @ReactMethod
     fun startSession(sessionID: String? = null, promise: Promise) {
-        val result = NeuroID.getInstance()?.startSession(sessionID)
-        val resultData = Arguments.createMap()
-        result?.let {
+        NeuroID.getInstance()?.startSession(sessionID) {
+            val resultData = Arguments.createMap()
             resultData.putString("sessionID", it.sessionID)
             resultData.putBoolean("started", it.started)
+            promise.resolve(resultData)
         }
-        promise.resolve(resultData)
     }
 
     @ReactMethod
@@ -194,5 +190,13 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         NeuroID.getInstance()?.resumeCollection()
     }
 
-    // setup page mising?
+    @ReactMethod
+    fun startAppFlow(siteId: String, userId: String?,  promise: Promise) {
+        NeuroID.getInstance()?.startAppFlow(siteId, userId) {
+            val resultData = Arguments.createMap()
+            resultData.putString("sessionID", it.sessionID)
+            resultData.putBoolean("started", it.started)
+            promise.resolve(resultData)
+        }
+    }
 }

--- a/ios/NeuroidReactnativeSdk.m
+++ b/ios/NeuroidReactnativeSdk.m
@@ -82,7 +82,10 @@ RCT_EXTERN_METHOD(pauseCollection: (RCTPromiseResolveBlock) resolve
 RCT_EXTERN_METHOD(resumeCollection: (RCTPromiseResolveBlock) resolve
                  withRejecter:(RCTPromiseRejectBlock) reject) 
 
-
+RCT_EXTERN_METHOD(startAppFlow:(NSString *)siteID
+                  userID:(NSString *)userID
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
 
 // missing setupPage?
 

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -101,9 +101,10 @@ class NeuroidReactnativeSdk: NSObject {
     }
 
     @objc(start:withRejecter:)
-    func start(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let result = NeuroID.start()
-        resolve(result)
+    func start(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        NeuroID.start() { result in 
+            resolve(result)
+        }
     }
 
     @objc(stop:withRejecter:)

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -137,10 +137,19 @@ class NeuroidReactnativeSdk: NSObject {
     }
 
     @objc(startSession:withResolver:withRejecter:)
-    func startSession(sessionID: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let result = NeuroID.startSession(sessionID)
-        let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
-        resolve(resultData)
+    func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        NeuroID.startSession(sessionID)  { result in
+            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+            resolve(resultData)
+        }
+    }
+    
+    @objc(startAppFlow:userID:withResolver:withRejecter:)
+    func startAppFlow(siteID: String, userID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        NeuroID.startAppFlow(siteID: siteID, userID: userID) { result in
+            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+            resolve(resultData)
+        }
     }
 
     // missing setupPage?

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -89,7 +89,7 @@ class NeuroidReactnativeSdk: NSObject {
     }
     
     @objc(attemptedLogin:withResolver:withRejecter:)
-    func attemptedLogin(userID: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    func attemptedLogin(userID: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let setResult = NeuroID.attemptedLogin(userID)
         resolve(setResult)
     }

--- a/neuroid-reactnative-sdk-types/src/types.d.ts
+++ b/neuroid-reactnative-sdk-types/src/types.d.ts
@@ -25,6 +25,7 @@ export interface NeuroIDClass {
     stopSession: () => Promise<boolean>;
     resumeCollection: () => Promise<void>;
     pauseCollection: () => Promise<void>;
+    startAppFlow: (siteID: string, userID: string) => Promise<SessionStartResult>;
 }
 export interface NeuroIDConfigOptions {
     usingReactNavigation: boolean;

--- a/neuroid-reactnative-sdk.podspec
+++ b/neuroid-reactnative-sdk.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'NeuroID', '3.2.0'
+  s.dependency 'NeuroID', '3.3.1'
   s.dependency "React-Core" 
 end

--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -21,12 +21,12 @@ sed -i='' 's/startSession: (NSString)sessionID /startSession: (NSString)sessionI
 
 # Add to ios function file
 sed -i='' 's/@objc(start:withRejecter:)/@objc(start:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/func start(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func start(advancedDeviceSignals: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/NeuroID.start()/NeuroID.start(advancedDeviceSignals)/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/func start(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func start(advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/NeuroID.start() { result in/NeuroID.start(advancedDeviceSignals) { result in/' ios/NeuroidReactnativeSdk.swift
 
 sed -i='' 's/@objc(startSession:withResolver:withRejecter:)/@objc(startSession:advancedDeviceSignals:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/func startSession(sessionID: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func startSession(sessionID: String?, advancedDeviceSignals: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/let result = NeuroID.startSession(sessionID)/let result = NeuroID.startSession(sessionID, advancedDeviceSignals)/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func startSession(sessionID: String?, advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/NeuroID.startSession(sessionID)  { result in/NeuroID.startSession(sessionID, advancedDeviceSignals)  { result in/' ios/NeuroidReactnativeSdk.swift
 
 
 # Implement code for Android actual 
@@ -36,14 +36,14 @@ import com.neuroid.tracker.extensions.startSession\
 ' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
 
 sed -i='' '/fun start(promise: Promise) {/i \
-    fun start(advancedDeviceSignals: Boolean, promise: Promise) {\
-        val started = NeuroID.getInstance()?.start(advancedDeviceSignals); \
-\
-        if (started != null){ \
-            promise.resolve(started) \
-        } else { \
-            promise.resolve(false) \
-        } \
+    fun start(advancedDeviceSignals: Boolean, promise: Promise) { \
+        NeuroID.getInstance()?.start(advancedDeviceSignals) { \
+            if (it != null){ \
+                promise.resolve(it) \
+            } else { \
+                promise.resolve(false) \
+            } \
+        }\
     }\
 \
     @ReactMethod\
@@ -51,13 +51,12 @@ sed -i='' '/fun start(promise: Promise) {/i \
 
 sed -i='' '/fun startSession(sessionID: String? = null, promise: Promise) {/i \
     fun startSession(sessionID: String? = null, advancedDeviceSignals: Boolean, promise: Promise) {\
-        val result = NeuroID.getInstance()?.startSession(sessionID, advancedDeviceSignals) \
-        val resultData = Arguments.createMap() \
-        result?.let { \
-            resultData.putString("sessionID", it.sessionID) \
-            resultData.putBoolean("started", it.started) \
-        } \
-        promise.resolve(resultData) \
+        NeuroID.getInstance()?.startSession(sessionID, advancedDeviceSignals) {\
+            val resultData = Arguments.createMap()\
+            resultData.putString("sessionID", it.sessionID)\
+            resultData.putBoolean("started", it.started)\
+            promise.resolve(resultData)\
+        }\
     }\
 \
     @ReactMethod\

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -251,10 +251,10 @@ export const NeuroID: NeuroIDClass = {
   },
 
   startAppFlow: async function startAppFlow(
-    siteID: string, userID: string
+    siteID: string, userID?: string
   ): Promise<SessionStartResult> {
     const result = await NeuroidReactnativeSdk.startAppFlow(siteID, userID);
-    NeuroIDLog.d('startSession(): ' + result.sessionID + ' ' + result.started);
+    NeuroIDLog.d('startAppFlow(): ' + result.sessionID + ' ' + result.started);
     return Promise.resolve({
       sessionID: result.sessionID as string,
       started: result.started as boolean,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -249,6 +249,17 @@ export const NeuroID: NeuroIDClass = {
     NeuroIDLog.d('resumeCollection()');
     return Promise.resolve();
   },
+
+  startAppFlow: async function startAppFlow(
+    siteID: string, userID: string
+  ): Promise<SessionStartResult> {
+    const result = await NeuroidReactnativeSdk.startAppFlow(siteID, userID);
+    NeuroIDLog.d('startSession(): ' + result.sessionID + ' ' + result.started);
+    return Promise.resolve({
+      sessionID: result.sessionID as string,
+      started: result.started as boolean,
+    } as SessionStartResult);
+  }
 };
 
 export default NeuroID;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,10 @@ export interface NeuroIDClass {
   stopSession: () => Promise<boolean>;
   resumeCollection: () => Promise<void>;
   pauseCollection: () => Promise<void>;
-  startAppFlow: (siteID: string, userID?: string) => Promise<SessionStartResult>;
+  startAppFlow: (
+    siteID: string,
+    userID?: string
+  ) => Promise<SessionStartResult>;
 }
 
 export interface NeuroIDConfigOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface NeuroIDClass {
   stopSession: () => Promise<boolean>;
   resumeCollection: () => Promise<void>;
   pauseCollection: () => Promise<void>;
+  startAppFlow: (siteID: string, userID?: string) => Promise<SessionStartResult>;
 }
 
 export interface NeuroIDConfigOptions {


### PR DESCRIPTION
- add startAppFlow()
- update startSession() to fire completion and return SessionStartResult. 
- advanced script updates

Tested on both iOS and Android in the neuroid-reactnative-sdk-sandbox with a startAppFlow() command added in the NewApplication.tsx
Tested on both iOS and Android advanced SDK versions (start and startSession)  

iOS is updated to use the 3.3.1 SDK
Android is updated to use the master-SNAPSHOT SDK