### PR TITLE
ENG-7831 use the new RN builder to support RN options in android

### DIFF
--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -3,19 +3,11 @@ package com.neuroidreactnativesdk
 import android.app.Application
 import com.facebook.react.bridge.*
 import com.neuroid.tracker.NeuroID
+import com.neuroid.tracker.extensions.NIDRNBuilder
 import com.neuroid.tracker.extensions.setVerifyIntegrationHealth
 
 class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         ReactContextBaseJavaModule(reactContext) {
-
-    companion object {
-        @JvmStatic
-        fun configure(application: Application, key: String) {
-            if (NeuroID.getInstance() == null) {
-                NeuroID.Builder(application, key).build()
-            }
-        }
-    }
 
     private var reactApplicationCtx: ReactApplicationContext = reactContext
     private var application: Application? = reactContext.applicationContext as Application
@@ -25,9 +17,9 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun configure(key: String, options: ReadableMap, promise: Promise) {
+    fun configure(key: String, options: ReadableMap? = null, promise: Promise) {
         if (NeuroID.getInstance() == null) {
-            NeuroID.Builder(application, key).build()
+            NIDRNBuilder(application, key, options).build()
             NeuroID.getInstance()?.setIsRN()
         }
 
@@ -35,7 +27,6 @@ class NeuroidReactnativeSdkModule(reactContext: ReactApplicationContext) :
         if (reactCurrentActivity != null) {
             NeuroID.getInstance()?.registerPageTargets(reactCurrentActivity)
         }
-
         promise.resolve(true)
     }
 

--- a/neuroid-reactnative-sdk-types/src/types.d.ts
+++ b/neuroid-reactnative-sdk-types/src/types.d.ts
@@ -33,7 +33,6 @@ export interface NeuroIDConfigOptions {
     isAdvancedDevice: boolean;
     environment: string;
 }
-
 export interface NeuroIDLogClass {
     enableLogging: (enable?: boolean) => void;
     log: (...message: String[]) => void;

--- a/neuroid-reactnative-sdk-types/src/types.d.ts
+++ b/neuroid-reactnative-sdk-types/src/types.d.ts
@@ -30,7 +30,10 @@ export interface NeuroIDClass {
 }
 export interface NeuroIDConfigOptions {
     usingReactNavigation: boolean;
+    isAdvancedDevice: boolean;
+    environment: string;
 }
+
 export interface NeuroIDLogClass {
     enableLogging: (enable?: boolean) => void;
     log: (...message: String[]) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,8 @@ export interface NeuroIDClass {
 
 export interface NeuroIDConfigOptions {
   usingReactNavigation: boolean;
+  isAdvancedDevice: boolean;
+  environment: string;
 }
 
 export interface NeuroIDLogClass {


### PR DESCRIPTION
ReactNative option handling in the configure() method has been added to the Android SDK to get the SDK to parity with iOS. The `environment` option allows switching between production and develop. The `isAdvancedDevice` allows enabling the advanced device feature. 

To test this, either build the ReactNative libs using ./gradlew NeuroID:assemble, copy and configure the ReactNative SDK to use the SDK libs or use the snapshots of this branch from jitpack. Pull the ENG-7831 branch in the ReactNative SDK repo, yarn and run NPX in the ReactNative SDK sandbox and modify App.tsx in the sandbox app with the following code to add the new remote options: 

`await NeuroID.configure('key_live_MwC5DQNYzRsRhnnYjvz1fJtp',  {
      environment:'prodscriptdevcollection',isAdvancedDevice:true,usingReactNavigation:true,
    });`

If it all works you should see this debug in logcat on running the ReactNative sandbox app with the appropriate configuration that was set in the sandbox app. 
`2024-07-10 23:07:50.680 20069-20131 NIDRNBuilder            com...idreactnativesdksandbox.debug  D  NIDRNBuilder isAdvancedDevice true environment: prodscriptdevcollection`