### PR TITLE
ENG-8986 update advanced script

### DIFF
--- a/scripts/advancedDeviceSetup.sh
+++ b/scripts/advancedDeviceSetup.sh
@@ -16,16 +16,16 @@ sed -i='' 's/neuroid-android-sdk:react-android-sdk/neuroid-android-sdk:react-and
 
 
 # Implement code for iOS header and actual
-sed -i='' 's/start:/start:(BOOL)advancedDeviceSignals\n                 withResolver:/' ios/NeuroidReactnativeSdk.m
-sed -i='' 's/startSession: (NSString)sessionID /startSession: (NSString)sessionID \n                 advancedDeviceSignals: (BOOL)advancedDeviceSignals/' ios/NeuroidReactnativeSdk.m
+sed -i='' 's/start:/startAdv:(BOOL)advancedDeviceSignals\n                 withResolver:/' ios/NeuroidReactnativeSdk.m
+sed -i='' 's/startSession: (NSString)sessionID /startSessionAdv: (NSString)sessionID \n                 advancedDeviceSignals: (BOOL)advancedDeviceSignals/' ios/NeuroidReactnativeSdk.m
 
 # Add to ios function file
-sed -i='' 's/@objc(start:withRejecter:)/@objc(start:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/func start(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func start(advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/@objc(start:withRejecter:)/@objc(startAdv:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/func start(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func startAdv(advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
 sed -i='' 's/NeuroID.start() { result in/NeuroID.start(advancedDeviceSignals) { result in/' ios/NeuroidReactnativeSdk.swift
 
-sed -i='' 's/@objc(startSession:withResolver:withRejecter:)/@objc(startSession:advancedDeviceSignals:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
-sed -i='' 's/func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func startSession(sessionID: String?, advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/@objc(startSession:withResolver:withRejecter:)/@objc(startSessionAdv:advancedDeviceSignals:withResolver:withRejecter:)/' ios/NeuroidReactnativeSdk.swift
+sed -i='' 's/func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/func startSessionAdv(sessionID: String?, advancedDeviceSignals: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {/' ios/NeuroidReactnativeSdk.swift
 sed -i='' 's/NeuroID.startSession(sessionID)  { result in/NeuroID.startSession(sessionID, advancedDeviceSignals)  { result in/' ios/NeuroidReactnativeSdk.swift
 
 
@@ -36,7 +36,7 @@ import com.neuroid.tracker.extensions.startSession\
 ' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
 
 sed -i='' '/fun start(promise: Promise) {/i \
-    fun start(advancedDeviceSignals: Boolean, promise: Promise) { \
+    fun startAdv(advancedDeviceSignals: Boolean, promise: Promise) { \
         NeuroID.getInstance()?.start(advancedDeviceSignals) { \
             if (it != null){ \
                 promise.resolve(it) \
@@ -50,7 +50,7 @@ sed -i='' '/fun start(promise: Promise) {/i \
 ' android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
 
 sed -i='' '/fun startSession(sessionID: String? = null, promise: Promise) {/i \
-    fun startSession(sessionID: String? = null, advancedDeviceSignals: Boolean, promise: Promise) {\
+    fun startSessionAdv(sessionID: String? = null, advancedDeviceSignals: Boolean, promise: Promise) {\
         NeuroID.getInstance()?.startSession(sessionID, advancedDeviceSignals) {\
             val resultData = Arguments.createMap()\
             resultData.putString("sessionID", it.sessionID)\
@@ -69,9 +69,9 @@ sed -i='' 's/startSession: (sessionID?: string)/startSession: (\n    sessionID?:
 
 # update index
 sed -i='' 's/start(): /start(advancedDeviceSignals?: Boolean): /' src/index.tsx
-sed -i='' 's/NeuroidReactnativeSdk.start()/\n          NeuroidReactnativeSdk.start(!!advancedDeviceSignals)\n        /' src/index.tsx
+sed -i='' 's/NeuroidReactnativeSdk.start()/\n          NeuroidReactnativeSdk.startAdv(!!advancedDeviceSignals)\n        /' src/index.tsx
 sed -i='' 's/sessionID?: string/sessionID?: string,\n    advancedDeviceSignals?: Boolean/' src/index.tsx
-sed -i='' 's/NeuroidReactnativeSdk.startSession(sessionID)/NeuroidReactnativeSdk.startSession(\n      sessionID,\n      !!advancedDeviceSignals\n    )/' src/index.tsx
+sed -i='' 's/NeuroidReactnativeSdk.startSession(sessionID)/NeuroidReactnativeSdk.startSessionAdv(\n      sessionID,\n      !!advancedDeviceSignals\n    )/' src/index.tsx
 
 
 # update package.json for new module name and description


### PR DESCRIPTION
Rename wrapper methods start() and startSession() to startAdv() and startSessionAdv() to fix duplicate method exception. 

See bug ticket for details.
https://neuro-id.atlassian.net/browse/ENG-8986

Android logcat: 
```
024-11-15 10:18:47.619 13025-13193 NeuroID Info            com.neuroidsampleapp                 D  NID remoteConfig: NIDRemoteConfig(callInProgress=true, eventQueueFlushInterval=5, eventQueueFlushSize=2000, geoLocation=false, gyroAccelCadence=false, gyroAccelCadenceTime=200, requestTimeout=10, linkedSiteOptions={form_parks912=NIDLinkedSiteOption(sampleRate=50), form_bench881=NIDLinkedSiteOption(sampleRate=0), form_hares612=NIDLinkedSiteOption(sampleRate=100)}, sampleRate=100, siteID=form_skein469)
2

2024-11-15 10:18:47.371 13025-13198 NeuroID Debug Event     com.neuroidsampleapp                 D  EVENT: ADVANCED_DEVICE_REQUEST - null - rid=1731625351081.oo1F8J, c=true, l=0, ct=wifi
```

iOS log: 
```
(NeuroID Debug) Event:  MOBILE_METADATA_IOS - 1731697262065 - NO_TARGET - latong=-1.0, -1.0
(NeuroID Debug) Event:  APPLICATION_METADATA - 1731697262065 - NO_TARGET - attrs=[versionName=1.0, versionNumber=1, packageName=org.reactjs.native.example.neuroidsampleapp, applicationName=neuroidsampleapp]
(NeuroID Debug) Event:  ADVANCED_DEVICE_REQUEST - 1731697262916 - NO_TARGET - rid=1731697262931.IIvpNT c=false l=Optional(570.4489946365356)
```