### PR TITLE
ENG-9965 snapshot reset, comment out slack notifier in gihub action…

### DIFF
--- a/.github/workflows/release_npm_version.yml
+++ b/.github/workflows/release_npm_version.yml
@@ -83,17 +83,17 @@ jobs:
             https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
             -d '{"event_type":"on-demand-testflight","client_payload":{"version":"${{env.PACKAGE_VERSION}}", "message": "${{ github.event.commit.message }}"}}'
 
-      - name: Send Slack Notification on Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: 'Failed to trigger React Native Sandbox release (Prod)'
-          SLACK_TITLE: Failed to trigger React Native Sandbox release (Prod)
-          SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
+      # - name: Send Slack Notification on Failure
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
+      #     SLACK_COLOR: ${{ job.status }}
+      #     SLACK_ICON: https://github.com/rtCamp.png?size=48
+      #     SLACK_MESSAGE: 'Failed to trigger React Native Sandbox release (Prod)'
+      #     SLACK_TITLE: Failed to trigger React Native Sandbox release (Prod)
+      #     SLACK_USERNAME: rtBot
+      #     SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
 
   resetAndroidVersion:
     name: Default to main snapshot

--- a/.github/workflows/update-android-sdk-dev.yml
+++ b/.github/workflows/update-android-sdk-dev.yml
@@ -41,14 +41,14 @@ jobs:
               https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
               -d '{"event_type":"publish-dev-android","client_payload":{"version":"main-SNAPSHOT", "message": "Android sdk main-SNAPSHOT"}}'
 
-      - name: Send Slack Notification on Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: 'Failed to trigger React Native Android Sandbox release (Dev)'
-          SLACK_TITLE: Failed to trigger React Native Android Sandbox release (Dev)
-          SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
+      # - name: Send Slack Notification on Failure
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
+      #     SLACK_COLOR: ${{ job.status }}
+      #     SLACK_ICON: https://github.com/rtCamp.png?size=48
+      #     SLACK_MESSAGE: 'Failed to trigger React Native Android Sandbox release (Dev)'
+      #     SLACK_TITLE: Failed to trigger React Native Android Sandbox release (Dev)
+      #     SLACK_USERNAME: rtBot
+      #     SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/.github/workflows/update-ios-sdk-dev.yml
+++ b/.github/workflows/update-ios-sdk-dev.yml
@@ -38,14 +38,14 @@ jobs:
           https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk-sandbox/dispatches \
           -d '{"event_type":"on-demand-testflight-dev","client_payload":{"version":"development", "message": "iOS development tag"}}'
 
-      - name: Send Slack Notification on Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: 'Failed to trigger React Native iOS Sandbox release (Dev)'
-          SLACK_TITLE: Failed to trigger React Native iOS Sandbox release (Dev)
-          SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
+      # - name: Send Slack Notification on Failure
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
+      #     SLACK_COLOR: ${{ job.status }}
+      #     SLACK_ICON: https://github.com/rtCamp.png?size=48
+      #     SLACK_MESSAGE: 'Failed to trigger React Native iOS Sandbox release (Dev)'
+      #     SLACK_TITLE: Failed to trigger React Native iOS Sandbox release (Dev)
+      #     SLACK_USERNAME: rtBot
+      #     SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,9 +131,8 @@ dependencies {
   api 'com.facebook.react:react-android:0.71.0-rc.1'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk:v3.5.8'
-  debugImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk-debug:v3.5.8'
-
+  releaseImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk:main-SNAPSHOT'
+  debugImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk-debug:main-SNAPSHOT'
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")


### PR DESCRIPTION
snapshot reset
comment out slack notifier in github actions due to failures.