### PR TITLE
ENG-10632 update NeuroID ReactNative lib with lowercase name

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,8 +131,8 @@ dependencies {
   api 'com.facebook.react:react-android:0.71.0-rc.1'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  releaseImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk:main-SNAPSHOT'
-  debugImplementation 'com.github.Neuro-ID.neuroid-android-sdk:react-android-sdk-debug:main-SNAPSHOT'
+  releaseImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:main-SNAPSHOT'
+  debugImplementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk-debug:main-SNAPSHOT'
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")


### PR DESCRIPTION
 Update NeuroID ReactNative lib with lowercase names to reference in jitpack

The ReactNative SDK is currently broken due to change in jitpack that was made recently that no longer accepts uppercase characters in the NeuroID SDK name and thus not allowing the NeuroID Android SDK to get retrieved when Metro is run. First found by Aspiration and now Gemini reported the issue. We need to make another ReactNative release 3.4.9 after this is merged. 

We will look into repository alternatives to jitpack in the near future to mitigate these issues. 