### PR TITLE
[ENG-11657] Fix: iOS integration test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
       matrix:
         include:
           - RN_VERSION: 'latest'
-            macos: 'macos-26'
+            macos: 'macos-26-xlarge'
 
           - RN_VERSION: '0.81-stable'
             macos: 'macos-26-xlarge'


### PR DESCRIPTION
Fix iOS integration test runner to use `macos-26-xlarge`.

[ENG-11657]

[ENG-11657]: https://neuro-id.atlassian.net/browse/ENG-11657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ