### PR TITLE
[ENG-11756] Isolate start functions to main actor

### DIFF
--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -95,8 +95,10 @@ class NeuroidReactnativeSdk: NSObject {
 
     @objc(start:withRejecter:)
     func start(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        NeuroID.start() { result in 
-            resolve(result)
+        Task { @MainActor in
+            NeuroID.start() { result in 
+                resolve(result)
+            }
         }
     }
 
@@ -132,17 +134,21 @@ class NeuroidReactnativeSdk: NSObject {
 
     @objc(startSession:withResolver:withRejecter:)
     func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        NeuroID.startSession(sessionID)  { result in
-            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
-            resolve(resultData)
+        Task { @MainActor in
+            NeuroID.startSession(sessionID)  { result in
+                let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+                resolve(resultData)
+            }
         }
     }
     
     @objc(startAppFlow:userID:withResolver:withRejecter:)
     func startAppFlow(siteID: String, userID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        NeuroID.startAppFlow(siteID: siteID, sessionID: userID) { result in
-            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
-            resolve(resultData)
+        Task { @MainActor in
+            NeuroID.startAppFlow(siteID: siteID, sessionID: userID) { result in
+                let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+                resolve(resultData)
+            }
         }
     }
 }


### PR DESCRIPTION
Explicitly require start, startSession, and startAppFlow to be called from the `@MainActor`. Required because these functions call and expect synchronous return on `@MainActor` isolated functions.

See: https://github.com/Neuro-ID/neuroid-ios-sdk/pull/384 for more context

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ