### PR TITLE
[ENG-11756] Isolate stop function to main actor

### DIFF
--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -103,9 +103,11 @@ class NeuroidReactnativeSdk: NSObject {
     }
 
     @objc(stop:withRejecter:)
-    func stop(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let result = NeuroID.stop()
-        resolve(result)
+    func stop(resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        Task { @MainActor in
+            let result = NeuroID.stop()
+            resolve(result)
+        }
     }
 
     @objc(registerPageTargets:withRejecter:)


### PR DESCRIPTION
Explicitly require `stop` to be called from the `@MainActor`. Required because this function calls and expects synchronous return on `@MainActor` an isolated function.

See: https://github.com/Neuro-ID/neuroid-ios-sdk/pull/385 for more context

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ