### PR TITLE
[ENG-11837] Fetch all tags for prod sandbox deploy

### DIFF
--- a/.github/workflows/sandbox-deploy-prod.yml
+++ b/.github/workflows/sandbox-deploy-prod.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Determine Version to Deploy
         id: version


### PR DESCRIPTION
Fix prod sandbox deploy workflow by fetching all tags when triggering manually.

[ENG-11837]

[ENG-11837]: https://neuro-id.atlassian.net/browse/ENG-11837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ