### PR TITLE
ENG-11869: setScreen deprecations

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -114,7 +114,6 @@ afterAll(() => {
 beforeEach(async () => {
   // Reset module-level usingRNNavigation flag to false before every test.
   // clearMocks (jest config) already cleared call counts; this resets SDK state.
-  native.configure.mockResolvedValue(true);
   await NeuroID.configure(VALID_LIVE_KEY, DEFAULT_CONFIG);
   // Clear the counts produced by the state-reset configure call above
   jest.clearAllMocks();
@@ -392,11 +391,26 @@ describe("NeuroID SDK", () => {
 
   // ── setScreenName ───────────────────────────────────────────────────────────
   describe("setScreenName", () => {
-    it("delegates to native with the screen name and resolves the result", async () => {
+    it("delegates to native with the screen name and registerPageTargets, resolves the result", async () => {
       native.setScreenName!.mockResolvedValue(true);
       native.registerPageTargets!.mockResolvedValue();
       const result = await NeuroID.setScreenName("LoginScreen");
       expect(native.setScreenName).toHaveBeenCalledWith("LoginScreen");
+      expect(native.registerPageTargets).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+    it("delegates to native with the screen name and skips registerPageTargets, resolves the result", async () => {
+      native.setScreenName!.mockResolvedValue(true);
+      native.registerPageTargets!.mockResolvedValue();
+      const opts = {
+        ...DEFAULT_CONFIG,
+        isAdvancedDevice: true,
+        usingReactNavigation: true,
+      };
+      await NeuroID.configure(VALID_LIVE_KEY, opts);
+      const result = await NeuroID.setScreenName("LoginScreen");
+      expect(native.setScreenName).toHaveBeenCalledWith("LoginScreen");
+      expect(native.registerPageTargets).not.toHaveBeenCalled();
       expect(result).toBe(true);
     });
   });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -9,35 +9,39 @@ import { version } from "../../package.json";
 jest.mock("react-native", () => ({
   NativeModules: {
     NeuroidReactnativeSdk: {
-      configure: jest.fn(),
-      enableLogging: jest.fn(),
-      excludeViewByTestID: jest.fn(),
-      getClientID: jest.fn(),
-      getEnvironment: jest.fn(),
-      getScreenName: jest.fn(),
-      getSessionID: jest.fn(),
-      getRegisteredUserID: jest.fn(),
-      getUserID: jest.fn(),
-      isStopped: jest.fn(),
-      setScreenName: jest.fn(),
+      configure: jest.fn().mockResolvedValue(true),
+      enableLogging: jest.fn().mockResolvedValue(undefined),
+      excludeViewByTestID: jest.fn().mockResolvedValue(undefined),
+      getClientID: jest.fn().mockResolvedValue(""),
+      getEnvironment: jest.fn().mockResolvedValue(""),
+      getScreenName: jest.fn().mockResolvedValue(""),
+      getSessionID: jest.fn().mockResolvedValue(""),
+      getRegisteredUserID: jest.fn().mockResolvedValue(""),
+      getUserID: jest.fn().mockResolvedValue(""),
+      isStopped: jest.fn().mockResolvedValue(false),
+      setScreenName: jest.fn().mockResolvedValue(true),
       setUserID: jest.fn(),
-      identify: jest.fn(),
+      identify: jest.fn().mockResolvedValue(true),
       setRegisteredUserID: jest.fn(),
       attemptedLogin: jest.fn(),
-      setVariable: jest.fn(),
-      start: jest.fn(),
-      stop: jest.fn(),
-      registerPageTargets: jest.fn(),
-      startSession: jest.fn(),
-      stopSession: jest.fn(),
-      pauseCollection: jest.fn(),
-      resumeCollection: jest.fn(),
-      startAppFlow: jest.fn(),
+      setVariable: jest.fn().mockResolvedValue(undefined),
+      start: jest.fn().mockResolvedValue(true),
+      stop: jest.fn().mockResolvedValue(true),
+      registerPageTargets: jest.fn().mockResolvedValue(undefined),
+      startSession: jest
+        .fn()
+        .mockResolvedValue({ sessionID: "", started: true }),
+      stopSession: jest.fn().mockResolvedValue(true),
+      pauseCollection: jest.fn().mockResolvedValue(undefined),
+      resumeCollection: jest.fn().mockResolvedValue(undefined),
+      startAppFlow: jest
+        .fn()
+        .mockResolvedValue({ sessionID: "", started: true }),
     },
   },
   Platform: {
     OS: "ios",
-    select: (obj: Record<string, unknown>) => obj["ios"] ?? obj["default"],
+    select: (obj: Record<string, unknown>) => obj.ios ?? obj.default,
     constants: {
       reactNativeVersion: { major: 0, minor: 76, patch: 0 },
     },
@@ -46,8 +50,41 @@ jest.mock("react-native", () => ({
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+type NativeSdkMock = {
+  configure: jest.Mock<Promise<boolean>, [string, unknown?]>;
+  enableLogging: jest.Mock<Promise<void>, [boolean?]>;
+  excludeViewByTestID: jest.Mock<Promise<void>, [string]>;
+  getClientID: jest.Mock<Promise<string>, []>;
+  getEnvironment: jest.Mock<Promise<string>, []>;
+  getScreenName: jest.Mock<Promise<string>, []>;
+  getSessionID: jest.Mock<Promise<string>, []>;
+  getRegisteredUserID: jest.Mock<Promise<string>, []>;
+  getUserID: jest.Mock<Promise<string>, []>;
+  isStopped: jest.Mock<Promise<boolean>, []>;
+  setScreenName: jest.Mock<Promise<boolean>, [string]>;
+  setUserID: jest.Mock<unknown, [string]>;
+  identify: jest.Mock<Promise<boolean>, [string]>;
+  setRegisteredUserID: jest.Mock<unknown, [string]>;
+  attemptedLogin: jest.Mock<unknown, [string?]>;
+  setVariable: jest.Mock<Promise<void>, [string, string]>;
+  start: jest.Mock<Promise<boolean>, []>;
+  stop: jest.Mock<Promise<boolean>, []>;
+  registerPageTargets: jest.Mock<Promise<void>, []>;
+  startSession: jest.Mock<
+    Promise<{ sessionID: string; started: boolean }>,
+    [string?]
+  >;
+  stopSession: jest.Mock<Promise<boolean>, []>;
+  pauseCollection: jest.Mock<Promise<void>, []>;
+  resumeCollection: jest.Mock<Promise<void>, []>;
+  startAppFlow: jest.Mock<
+    Promise<{ sessionID: string; started: boolean }>,
+    [string, string?]
+  >;
+};
+
 /** Typed shortcut to all mock functions on the native module */
-const native = NativeModules.NeuroidReactnativeSdk as Record<string, jest.Mock>;
+const native = NativeModules.NeuroidReactnativeSdk as unknown as NativeSdkMock;
 
 const VALID_LIVE_KEY = "key_live_abc123";
 const VALID_TEST_KEY = "key_test_abc123";
@@ -77,7 +114,7 @@ afterAll(() => {
 beforeEach(async () => {
   // Reset module-level usingRNNavigation flag to false before every test.
   // clearMocks (jest config) already cleared call counts; this resets SDK state.
-  native["configure"]!.mockResolvedValue(true);
+  native.configure.mockResolvedValue(true);
   await NeuroID.configure(VALID_LIVE_KEY, DEFAULT_CONFIG);
   // Clear the counts produced by the state-reset configure call above
   jest.clearAllMocks();
@@ -93,47 +130,47 @@ describe("NeuroID SDK", () => {
     it("returns false for an invalid API key without calling native", async () => {
       const result = await NeuroID.configure(INVALID_KEY, DEFAULT_CONFIG);
       expect(result).toBe(false);
-      expect(native["configure"]).not.toHaveBeenCalled();
+      expect(native.configure).not.toHaveBeenCalled();
     });
 
     it("accepts a valid live key and calls native", async () => {
-      native["configure"]!.mockResolvedValue(true);
+      native.configure!.mockResolvedValue(true);
       const result = await NeuroID.configure(VALID_LIVE_KEY, DEFAULT_CONFIG);
       expect(result).toBe(true);
-      expect(native["configure"]).toHaveBeenCalledTimes(1);
+      expect(native.configure).toHaveBeenCalledTimes(1);
     });
 
     it("accepts a valid test key and calls native", async () => {
-      native["configure"]!.mockResolvedValue(true);
+      native.configure!.mockResolvedValue(true);
       const result = await NeuroID.configure(VALID_TEST_KEY, DEFAULT_CONFIG);
       expect(result).toBe(true);
-      expect(native["configure"]).toHaveBeenCalledTimes(1);
+      expect(native.configure).toHaveBeenCalledTimes(1);
     });
 
     it("returns false when native configure returns false", async () => {
-      native["configure"]!.mockResolvedValue(false);
+      native.configure!.mockResolvedValue(false);
       const result = await NeuroID.configure(VALID_LIVE_KEY, DEFAULT_CONFIG);
       expect(result).toBe(false);
     });
 
     it("auto-injects the detected React Native version into options", async () => {
-      native["configure"]!.mockResolvedValue(true);
+      native.configure!.mockResolvedValue(true);
       await NeuroID.configure(VALID_LIVE_KEY, DEFAULT_CONFIG);
-      expect(native["configure"]).toHaveBeenCalledWith(
+      expect(native.configure).toHaveBeenCalledWith(
         VALID_LIVE_KEY,
         expect.objectContaining({ rnVersion: "0.76.0" })
       );
     });
 
     it("preserves all caller-provided config options alongside the injected version", async () => {
-      native["configure"]!.mockResolvedValue(true);
+      native.configure!.mockResolvedValue(true);
       const opts = {
         ...DEFAULT_CONFIG,
         isAdvancedDevice: true,
         environment: "production",
       };
       await NeuroID.configure(VALID_LIVE_KEY, opts);
-      expect(native["configure"]).toHaveBeenCalledWith(
+      expect(native.configure).toHaveBeenCalledWith(
         VALID_LIVE_KEY,
         expect.objectContaining({
           isAdvancedDevice: true,
@@ -158,15 +195,15 @@ describe("NeuroID SDK", () => {
   // ── start ───────────────────────────────────────────────────────────────────
   describe("start", () => {
     it("resolves the native result when start succeeds", async () => {
-      native["start"]!.mockResolvedValue(true);
-      native["getSessionID"]!.mockResolvedValue("sid-123");
+      native.start!.mockResolvedValue(true);
+      native.getSessionID!.mockResolvedValue("sid-123");
       const result = await NeuroID.start();
       expect(result).toBe(true);
-      expect(native["start"]).toHaveBeenCalled();
+      expect(native.start).toHaveBeenCalled();
     });
 
     it("resolves false (does not throw) when native start rejects", async () => {
-      native["start"]!.mockRejectedValue(new Error("device error"));
+      native.start!.mockRejectedValue(new Error("device error"));
       const result = await NeuroID.start();
       expect(result).toBe(false);
     });
@@ -175,13 +212,13 @@ describe("NeuroID SDK", () => {
   // ── stop ────────────────────────────────────────────────────────────────────
   describe("stop", () => {
     it("resolves the native result when stop succeeds", async () => {
-      native["stop"]!.mockResolvedValue(true);
+      native.stop!.mockResolvedValue(true);
       const result = await NeuroID.stop();
       expect(result).toBe(true);
     });
 
     it("resolves false (does not throw) when native stop rejects", async () => {
-      native["stop"]!.mockRejectedValue(new Error("device error"));
+      native.stop!.mockRejectedValue(new Error("device error"));
       const result = await NeuroID.stop();
       expect(result).toBe(false);
     });
@@ -190,13 +227,13 @@ describe("NeuroID SDK", () => {
   // ── setRegisteredUserID ─────────────────────────────────────────────────────
   describe("setRegisteredUserID", () => {
     it("resolves true when native returns truthy", async () => {
-      native["setRegisteredUserID"]!.mockReturnValue(true);
+      native.setRegisteredUserID!.mockReturnValue(true);
       await expect(NeuroID.setRegisteredUserID("reg-user")).resolves.toBe(true);
-      expect(native["setRegisteredUserID"]).toHaveBeenCalledWith("reg-user");
+      expect(native.setRegisteredUserID).toHaveBeenCalledWith("reg-user");
     });
 
     it("rejects false when native returns falsy", async () => {
-      native["setRegisteredUserID"]!.mockReturnValue(null);
+      native.setRegisteredUserID!.mockReturnValue(null);
       await expect(NeuroID.setRegisteredUserID("reg-user")).rejects.toBe(false);
     });
   });
@@ -204,19 +241,19 @@ describe("NeuroID SDK", () => {
   // ── attemptedLogin ──────────────────────────────────────────────────────────
   describe("attemptedLogin", () => {
     it("resolves true when native returns truthy", async () => {
-      native["attemptedLogin"]!.mockReturnValue(true);
+      native.attemptedLogin!.mockReturnValue(true);
       await expect(NeuroID.attemptedLogin("login-user")).resolves.toBe(true);
-      expect(native["attemptedLogin"]).toHaveBeenCalledWith("login-user");
+      expect(native.attemptedLogin).toHaveBeenCalledWith("login-user");
     });
 
     it("falls back to empty string when userID is nullish", async () => {
-      native["attemptedLogin"]!.mockReturnValue(true);
+      native.attemptedLogin!.mockReturnValue(true);
       await NeuroID.attemptedLogin(undefined as unknown as string);
-      expect(native["attemptedLogin"]).toHaveBeenCalledWith("");
+      expect(native.attemptedLogin).toHaveBeenCalledWith("");
     });
 
     it("rejects false when native returns falsy", async () => {
-      native["attemptedLogin"]!.mockReturnValue(null);
+      native.attemptedLogin!.mockReturnValue(null);
       await expect(NeuroID.attemptedLogin("user")).rejects.toBe(false);
     });
   });
@@ -224,13 +261,13 @@ describe("NeuroID SDK", () => {
   // ── registerPageTargets ─────────────────────────────────────────────────────
   describe("registerPageTargets", () => {
     it("calls native on iOS when not using React Navigation", async () => {
-      native["registerPageTargets"]!.mockReturnValue(undefined);
+      native.registerPageTargets!.mockResolvedValue(undefined);
       await NeuroID.registerPageTargets();
-      expect(native["registerPageTargets"]).toHaveBeenCalled();
+      expect(native.registerPageTargets).toHaveBeenCalled();
     });
 
     it("does NOT call native on iOS when using React Navigation", async () => {
-      native["configure"]!.mockResolvedValue(true);
+      native.configure!.mockResolvedValue(true);
       await NeuroID.configure(VALID_LIVE_KEY, {
         ...DEFAULT_CONFIG,
         usingReactNavigation: true,
@@ -238,56 +275,56 @@ describe("NeuroID SDK", () => {
       jest.clearAllMocks();
 
       await NeuroID.registerPageTargets();
-      expect(native["registerPageTargets"]).not.toHaveBeenCalled();
+      expect(native.registerPageTargets).not.toHaveBeenCalled();
     });
 
     it("calls native on Android regardless of the React Navigation setting", async () => {
       (Platform as unknown as { OS: string }).OS = "android";
-      native["registerPageTargets"]!.mockReturnValue(undefined);
+      native.registerPageTargets!.mockResolvedValue(undefined);
       await NeuroID.registerPageTargets();
-      expect(native["registerPageTargets"]).toHaveBeenCalled();
+      expect(native.registerPageTargets).toHaveBeenCalled();
     });
   });
 
   // ── setupPage ───────────────────────────────────────────────────────────────
   describe("setupPage", () => {
     it("calls setScreenName then registerPageTargets with the screen name", async () => {
-      native["setScreenName"]!.mockReturnValue(true);
-      native["registerPageTargets"]!.mockReturnValue(undefined);
+      native.setScreenName!.mockResolvedValue(true);
+      native.registerPageTargets!.mockResolvedValue(undefined);
       await NeuroID.setupPage("HomeScreen");
-      expect(native["setScreenName"]).toHaveBeenCalledWith("HomeScreen");
-      expect(native["registerPageTargets"]).toHaveBeenCalled();
+      expect(native.setScreenName).toHaveBeenCalledWith("HomeScreen");
+      expect(native.registerPageTargets).toHaveBeenCalled();
     });
   });
 
   // ── enableLogging ───────────────────────────────────────────────────────────
   describe("enableLogging", () => {
     it("calls native enableLogging with true", async () => {
-      native["enableLogging"]!.mockReturnValue(undefined);
+      native.enableLogging!.mockResolvedValue(undefined);
       await NeuroID.enableLogging(true);
-      expect(native["enableLogging"]).toHaveBeenCalledWith(true);
+      expect(native.enableLogging).toHaveBeenCalledWith(true);
     });
 
     it("calls native enableLogging with false", async () => {
-      native["enableLogging"]!.mockReturnValue(undefined);
+      native.enableLogging!.mockResolvedValue(undefined);
       await NeuroID.enableLogging(false);
-      expect(native["enableLogging"]).toHaveBeenCalledWith(false);
+      expect(native.enableLogging).toHaveBeenCalledWith(false);
     });
   });
 
   // ── excludeViewByTestID ─────────────────────────────────────────────────────
   describe("excludeViewByTestID", () => {
     it("delegates to native with the provided view ID", async () => {
-      native["excludeViewByTestID"]!.mockReturnValue(undefined);
+      native.excludeViewByTestID!.mockResolvedValue(undefined);
       await NeuroID.excludeViewByTestID("my-test-id");
-      expect(native["excludeViewByTestID"]).toHaveBeenCalledWith("my-test-id");
+      expect(native.excludeViewByTestID).toHaveBeenCalledWith("my-test-id");
     });
   });
 
   // ── getClientID ─────────────────────────────────────────────────────────────
   describe("getClientID", () => {
     it("resolves the value returned by native", async () => {
-      native["getClientID"]!.mockReturnValue("client-abc");
+      native.getClientID!.mockResolvedValue("client-abc");
       const result = await NeuroID.getClientID();
       expect(result).toBe("client-abc");
     });
@@ -296,7 +333,7 @@ describe("NeuroID SDK", () => {
   // ── getEnvironment ──────────────────────────────────────────────────────────
   describe("getEnvironment", () => {
     it("resolves the value returned by native", async () => {
-      native["getEnvironment"]!.mockReturnValue("production");
+      native.getEnvironment!.mockResolvedValue("production");
       const result = await NeuroID.getEnvironment();
       expect(result).toBe("production");
     });
@@ -305,7 +342,7 @@ describe("NeuroID SDK", () => {
   // ── getScreenName ───────────────────────────────────────────────────────────
   describe("getScreenName", () => {
     it("resolves the value returned by native", async () => {
-      native["getScreenName"]!.mockReturnValue("HomeScreen");
+      native.getScreenName!.mockResolvedValue("HomeScreen");
       const result = await NeuroID.getScreenName();
       expect(result).toBe("HomeScreen");
     });
@@ -314,7 +351,7 @@ describe("NeuroID SDK", () => {
   // ── getSessionID ────────────────────────────────────────────────────────────
   describe("getSessionID", () => {
     it("resolves the value returned by native", async () => {
-      native["getSessionID"]!.mockReturnValue("session-xyz");
+      native.getSessionID!.mockResolvedValue("session-xyz");
       const result = await NeuroID.getSessionID();
       expect(result).toBe("session-xyz");
     });
@@ -323,7 +360,7 @@ describe("NeuroID SDK", () => {
   // ── getUserID ───────────────────────────────────────────────────────────────
   describe("getUserID", () => {
     it("resolves the value returned by native", async () => {
-      native["getUserID"]!.mockReturnValue("user-123");
+      native.getUserID!.mockResolvedValue("user-123");
       const result = await NeuroID.getUserID();
       expect(result).toBe("user-123");
     });
@@ -332,7 +369,7 @@ describe("NeuroID SDK", () => {
   // ── getRegisteredUserID ─────────────────────────────────────────────────────
   describe("getRegisteredUserID", () => {
     it("resolves the value returned by native", async () => {
-      native["getRegisteredUserID"]!.mockReturnValue("reg-456");
+      native.getRegisteredUserID!.mockResolvedValue("reg-456");
       const result = await NeuroID.getRegisteredUserID();
       expect(result).toBe("reg-456");
     });
@@ -341,13 +378,13 @@ describe("NeuroID SDK", () => {
   // ── isStopped ───────────────────────────────────────────────────────────────
   describe("isStopped", () => {
     it("resolves true when native returns true", async () => {
-      native["isStopped"]!.mockReturnValue(true);
+      native.isStopped!.mockResolvedValue(true);
       const result = await NeuroID.isStopped();
       expect(result).toBe(true);
     });
 
     it("resolves false when native returns false", async () => {
-      native["isStopped"]!.mockReturnValue(false);
+      native.isStopped!.mockResolvedValue(false);
       const result = await NeuroID.isStopped();
       expect(result).toBe(false);
     });
@@ -356,9 +393,10 @@ describe("NeuroID SDK", () => {
   // ── setScreenName ───────────────────────────────────────────────────────────
   describe("setScreenName", () => {
     it("delegates to native with the screen name and resolves the result", async () => {
-      native["setScreenName"]!.mockReturnValue(true);
+      native.setScreenName!.mockResolvedValue(true);
+      native.registerPageTargets!.mockResolvedValue();
       const result = await NeuroID.setScreenName("LoginScreen");
-      expect(native["setScreenName"]).toHaveBeenCalledWith("LoginScreen");
+      expect(native.setScreenName).toHaveBeenCalledWith("LoginScreen");
       expect(result).toBe(true);
     });
   });
@@ -366,13 +404,13 @@ describe("NeuroID SDK", () => {
   // ── setUserID ───────────────────────────────────────────────────────────────
   describe("setUserID", () => {
     it("resolves true when native returns truthy", async () => {
-      native["setUserID"]!.mockReturnValue(true);
+      native.setUserID!.mockReturnValue(true);
       await expect(NeuroID.setUserID("user-abc")).resolves.toBe(true);
-      expect(native["setUserID"]).toHaveBeenCalledWith("user-abc");
+      expect(native.setUserID).toHaveBeenCalledWith("user-abc");
     });
 
     it("rejects false when native returns falsy", async () => {
-      native["setUserID"]!.mockReturnValue(null);
+      native.setUserID!.mockReturnValue(null);
       await expect(NeuroID.setUserID("user-abc")).rejects.toBe(false);
     });
   });
@@ -380,13 +418,13 @@ describe("NeuroID SDK", () => {
   // ── identify ───────────────────────────────────────────────────────────────
   describe("identify", () => {
     it("resolves true when native returns truthy", async () => {
-      native["identify"]!.mockResolvedValue(true);
+      native.identify!.mockResolvedValue(true);
       await expect(NeuroID.identify("session-abc")).resolves.toBe(true);
-      expect(native["identify"]).toHaveBeenCalledWith("session-abc");
+      expect(native.identify).toHaveBeenCalledWith("session-abc");
     });
 
     it("resolves false when native returns false", async () => {
-      native["identify"]!.mockResolvedValue(false);
+      native.identify!.mockResolvedValue(false);
       await expect(NeuroID.identify("session-abc")).resolves.toBe(false);
     });
   });
@@ -394,16 +432,16 @@ describe("NeuroID SDK", () => {
   // ── setVariable ─────────────────────────────────────────────────────────────
   describe("setVariable", () => {
     it("delegates key and value to native", async () => {
-      native["setVariable"]!.mockResolvedValue(undefined);
+      native.setVariable!.mockResolvedValue(undefined);
       await NeuroID.setVariable("myKey", "myVal");
-      expect(native["setVariable"]).toHaveBeenCalledWith("myKey", "myVal");
+      expect(native.setVariable).toHaveBeenCalledWith("myKey", "myVal");
     });
   });
 
   // ── startSession ────────────────────────────────────────────────────────────
   describe("startSession", () => {
     it("resolves a SessionStartResult with sessionID and started flag", async () => {
-      native["startSession"]!.mockResolvedValue({
+      native.startSession!.mockResolvedValue({
         sessionID: "sess-001",
         started: true,
       });
@@ -412,25 +450,25 @@ describe("NeuroID SDK", () => {
     });
 
     it("passes an explicit sessionID to native when provided", async () => {
-      native["startSession"]!.mockResolvedValue({
+      native.startSession!.mockResolvedValue({
         sessionID: "custom-id",
         started: true,
       });
       await NeuroID.startSession("custom-id");
-      expect(native["startSession"]).toHaveBeenCalledWith("custom-id");
+      expect(native.startSession).toHaveBeenCalledWith("custom-id");
     });
   });
 
   // ── stopSession ─────────────────────────────────────────────────────────────
   describe("stopSession", () => {
     it("resolves true when native returns true", async () => {
-      native["stopSession"]!.mockResolvedValue(true);
+      native.stopSession!.mockResolvedValue(true);
       const result = await NeuroID.stopSession();
       expect(result).toBe(true);
     });
 
     it("resolves false when native returns false", async () => {
-      native["stopSession"]!.mockResolvedValue(false);
+      native.stopSession!.mockResolvedValue(false);
       const result = await NeuroID.stopSession();
       expect(result).toBe(false);
     });
@@ -439,46 +477,40 @@ describe("NeuroID SDK", () => {
   // ── pauseCollection ─────────────────────────────────────────────────────────
   describe("pauseCollection", () => {
     it("calls native pauseCollection", async () => {
-      native["pauseCollection"]!.mockReturnValue(undefined);
+      native.pauseCollection!.mockResolvedValue(undefined);
       await NeuroID.pauseCollection();
-      expect(native["pauseCollection"]).toHaveBeenCalled();
+      expect(native.pauseCollection).toHaveBeenCalled();
     });
   });
 
   // ── resumeCollection ────────────────────────────────────────────────────────
   describe("resumeCollection", () => {
     it("calls native resumeCollection", async () => {
-      native["resumeCollection"]!.mockReturnValue(undefined);
+      native.resumeCollection!.mockResolvedValue(undefined);
       await NeuroID.resumeCollection();
-      expect(native["resumeCollection"]).toHaveBeenCalled();
+      expect(native.resumeCollection).toHaveBeenCalled();
     });
   });
 
   // ── startAppFlow ────────────────────────────────────────────────────────────
   describe("startAppFlow", () => {
     it("resolves a SessionStartResult with siteID and optional userID", async () => {
-      native["startAppFlow"]!.mockResolvedValue({
+      native.startAppFlow!.mockResolvedValue({
         sessionID: "app-sess-001",
         started: true,
       });
       const result = await NeuroID.startAppFlow("site-xyz", "user-abc");
-      expect(native["startAppFlow"]).toHaveBeenCalledWith(
-        "site-xyz",
-        "user-abc"
-      );
+      expect(native.startAppFlow).toHaveBeenCalledWith("site-xyz", "user-abc");
       expect(result).toEqual({ sessionID: "app-sess-001", started: true });
     });
 
     it("works without an optional userID", async () => {
-      native["startAppFlow"]!.mockResolvedValue({
+      native.startAppFlow!.mockResolvedValue({
         sessionID: "app-sess-002",
         started: true,
       });
       const result = await NeuroID.startAppFlow("site-xyz");
-      expect(native["startAppFlow"]).toHaveBeenCalledWith(
-        "site-xyz",
-        undefined
-      );
+      expect(native.startAppFlow).toHaveBeenCalledWith("site-xyz", undefined);
       expect(result.started).toBe(true);
     });
   });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -84,7 +84,7 @@ type NativeSdkMock = {
 };
 
 /** Typed shortcut to all mock functions on the native module */
-const native = NativeModules.NeuroidReactnativeSdk as unknown as NativeSdkMock;
+const native = NativeModules.NeuroidReactnativeSdk as NativeSdkMock;
 
 const VALID_LIVE_KEY = "key_live_abc123";
 const VALID_TEST_KEY = "key_test_abc123";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ const registerPageTargetsInternal = (): Promise<void> => {
     return Promise.resolve();
   }
 
-  return NeuroidReactnativeSdk.registerPageTargets();
+  return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
 };
 export const NeuroID: NeuroIDClass = {
   configure: async function configure(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,13 @@ let usingRNNavigation = false;
 type NativeConfigOptions = Partial<NeuroIDConfigOptions> & {
   rnVersion: string;
 };
+const registerPageTargetsInternal = (): Promise<void> => {
+  if (Platform.OS === "ios" && usingRNNavigation) {
+    return Promise.resolve();
+  }
 
+  return NeuroidReactnativeSdk.registerPageTargets();
+};
 export const NeuroID: NeuroIDClass = {
   configure: async function configure(
     apiKey: string,
@@ -209,11 +215,7 @@ export const NeuroID: NeuroIDClass = {
     NeuroIDLog.w(
       "registerPageTargets() is deprecated and will be removed in the next major version. /n Use setupScreen() independently to replicate this functionality."
     );
-    if (Platform.OS === "ios" && usingRNNavigation) {
-      return Promise.resolve();
-    }
-
-    return NeuroidReactnativeSdk.registerPageTargets();
+    return registerPageTargetsInternal();
   },
 
   setupPage: async function setupPage(screenName: string): Promise<void> {
@@ -222,7 +224,7 @@ export const NeuroID: NeuroIDClass = {
     );
     await NeuroidReactnativeSdk.setScreenName(screenName);
 
-    return NeuroidReactnativeSdk.registerPageTargets();
+    return registerPageTargetsInternal();
   },
 
   startSession: async function startSession(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -115,6 +115,9 @@ export const NeuroID: NeuroIDClass = {
 
   setScreenName: function setScreenName(screenName: string): Promise<boolean> {
     NeuroIDLog.d("setScreenName()", screenName);
+    registerPageTargetsInternal().catch((err) => {
+      NeuroIDLog.e("registerPageTargets failed", err);
+    });
     return NeuroidReactnativeSdk.setScreenName(screenName);
   },
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,17 +73,15 @@ export const NeuroID: NeuroIDClass = {
   excludeViewByTestID: function excludeViewByTestID(
     excludedView: string
   ): Promise<void> {
-    return Promise.resolve(
-      NeuroidReactnativeSdk.excludeViewByTestID(excludedView)
-    );
+    return NeuroidReactnativeSdk.excludeViewByTestID(excludedView);
   },
 
   getClientID: function getClientID(): Promise<string> {
-    return Promise.resolve(NeuroidReactnativeSdk.getClientID());
+    return NeuroidReactnativeSdk.getClientID();
   },
 
   getEnvironment: function getEnvironment(): Promise<string> {
-    return Promise.resolve(NeuroidReactnativeSdk.getEnvironment());
+    return NeuroidReactnativeSdk.getEnvironment();
   },
 
   getSDKVersion: function getSDKVersion(): Promise<string> {
@@ -91,11 +89,11 @@ export const NeuroID: NeuroIDClass = {
   },
 
   getScreenName: function getScreenName(): Promise<string> {
-    return Promise.resolve(NeuroidReactnativeSdk.getScreenName());
+    return NeuroidReactnativeSdk.getScreenName();
   },
 
   getSessionID: function getSessionID(): Promise<string> {
-    return Promise.resolve(NeuroidReactnativeSdk.getSessionID());
+    return NeuroidReactnativeSdk.getSessionID();
   },
 
   /** @deprecated Use getSessionId() instead. */
@@ -103,20 +101,20 @@ export const NeuroID: NeuroIDClass = {
     NeuroIDLog.w(
       "getUserId() is deprecated and will be removed in the next major version. Replace with getSessionID()"
     );
-    return Promise.resolve(NeuroidReactnativeSdk.getUserID());
+    return NeuroidReactnativeSdk.getUserID();
   },
 
   getRegisteredUserID: function getUserID(): Promise<string> {
-    return Promise.resolve(NeuroidReactnativeSdk.getRegisteredUserID());
+    return NeuroidReactnativeSdk.getRegisteredUserID();
   },
 
   isStopped: function isStopped(): Promise<boolean> {
-    return Promise.resolve(NeuroidReactnativeSdk.isStopped());
+    return NeuroidReactnativeSdk.isStopped();
   },
 
   setScreenName: function setScreenName(screenName: string): Promise<boolean> {
     NeuroIDLog.d("setScreenName()", screenName);
-    return Promise.resolve(NeuroidReactnativeSdk.setScreenName(screenName));
+    return NeuroidReactnativeSdk.setScreenName(screenName);
   },
 
   /** @deprecated Use identify(userID) instead. */
@@ -213,14 +211,11 @@ export const NeuroID: NeuroIDClass = {
   },
 
   registerPageTargets: function registerPageTargets(): Promise<void> {
-    if (Platform.OS === "ios") {
-      if (!usingRNNavigation) {
-        return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
-      } else {
-        return Promise.resolve();
-      }
+    if (Platform.OS === "ios" && usingRNNavigation) {
+      return Promise.resolve();
+    } else {
+      return NeuroidReactnativeSdk.registerPageTargets();
     }
-    return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
   },
 
   setupPage: async function setupPage(screenName: string): Promise<void> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ const registerPageTargetsInternal = (): Promise<void> => {
     return Promise.resolve();
   }
 
-  return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
+  return NeuroidReactnativeSdk.registerPageTargets();
 };
 export const NeuroID: NeuroIDClass = {
   configure: async function configure(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -109,7 +109,7 @@ export const NeuroID: NeuroIDClass = {
 
   setScreenName: function setScreenName(screenName: string): Promise<boolean> {
     NeuroIDLog.d("setScreenName()", screenName);
-    return NeuroidReactnativeSdk.setScreenName();
+    return NeuroidReactnativeSdk.setScreenName(screenName);
   },
 
   /** @deprecated Use identify(userID) instead. */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,12 +52,7 @@ export const NeuroID: NeuroIDClass = {
       rnVersion: detectedVersion,
     };
 
-    const configured = await NeuroidReactnativeSdk.configure(
-      apiKey,
-      optionsWithRNVersion
-    );
-
-    return Promise.resolve(configured);
+    return NeuroidReactnativeSdk.configure(apiKey, optionsWithRNVersion);
   },
 
   enableLogging: function enableLogging(enable?: boolean): Promise<void> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -217,7 +217,7 @@ export const NeuroID: NeuroIDClass = {
     );
     return registerPageTargetsInternal();
   },
-
+  /** @deprecated Use setScreenName(sessionId) instead. */
   setupPage: async function setupPage(screenName: string): Promise<void> {
     NeuroIDLog.w(
       "setupPage() is deprecated and will be removed in the next major version. /n Use setupScreen() independently to replicate this functionality."

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,7 +114,7 @@ export const NeuroID: NeuroIDClass = {
 
   setScreenName: function setScreenName(screenName: string): Promise<boolean> {
     NeuroIDLog.d("setScreenName()", screenName);
-    return NeuroidReactnativeSdk.setScreenName(screenName);
+    return NeuroidReactnativeSdk.setScreenName();
   },
 
   /** @deprecated Use identify(userID) instead. */
@@ -211,17 +211,23 @@ export const NeuroID: NeuroIDClass = {
   },
 
   registerPageTargets: function registerPageTargets(): Promise<void> {
+    NeuroIDLog.w(
+      "registerPageTargets() is deprecated and will be removed in the next major version. /n Use setupScreen() independently to replicate this functionality."
+    );
     if (Platform.OS === "ios" && usingRNNavigation) {
       return Promise.resolve();
-    } else {
-      return NeuroidReactnativeSdk.registerPageTargets();
     }
+
+    return NeuroidReactnativeSdk.registerPageTargets();
   },
 
   setupPage: async function setupPage(screenName: string): Promise<void> {
-    await Promise.resolve(NeuroidReactnativeSdk.setScreenName(screenName));
+    NeuroIDLog.w(
+      "setupPage() is deprecated and will be removed in the next major version. /n Use setupScreen() independently to replicate this functionality."
+    );
+    await NeuroidReactnativeSdk.setScreenName(screenName);
 
-    return Promise.resolve(NeuroidReactnativeSdk.registerPageTargets());
+    return NeuroidReactnativeSdk.registerPageTargets();
   },
 
   startSession: async function startSession(

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface NeuroIDClass {
 
   start: () => Promise<boolean>;
   stop: () => Promise<boolean>;
-
+  /** @deprecated Use setScreenName(sessionId) instead. */
   registerPageTargets: () => Promise<void>;
   setupPage: (screenName: string) => Promise<void>;
   startSession: (sessionID?: string) => Promise<SessionStartResult>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface NeuroIDClass {
   stop: () => Promise<boolean>;
   /** @deprecated Use setScreenName(sessionId) instead. */
   registerPageTargets: () => Promise<void>;
+  /** @deprecated Use setScreenName(sessionId) instead. */
   setupPage: (screenName: string) => Promise<void>;
   startSession: (sessionID?: string) => Promise<SessionStartResult>;
   stopSession: () => Promise<boolean>;

--- a/tests/SmokeRunner.ts
+++ b/tests/SmokeRunner.ts
@@ -52,8 +52,8 @@ export async function runSmoke(): Promise<void> {
     { name: "setScreenName", run: () => NeuroID.setScreenName("TestScreen") },
     { name: "getScreenName", run: () => NeuroID.getScreenName() },
     { name: "getSessionID", run: () => NeuroID.getSessionID() },
-    { name: "registerPageTargets", run: () => NeuroID.registerPageTargets() },
-    { name: "setupPage", run: () => NeuroID.setupPage("SetupPageScreen") },
+    { name: "registerPageTargets", run: () => NeuroID.registerPageTargets() }, // NOSONAR: intentional deprecated API smoke coverage
+    { name: "setupPage", run: () => NeuroID.setupPage("SetupPageScreen") }, // NOSONAR: intentional deprecated API smoke coverage
     { name: "isStopped", run: () => !NeuroID.isStopped() },
     { name: "identify", run: () => NeuroID.identify("smoke_user_123") },
     { name: "pauseCollection", run: () => NeuroID.pauseCollection() },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,20 +2,17 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "neuroid-reactnative-sdk": [
-        "./src/index"
-      ]
+      "neuroid-reactnative-sdk": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "node",
+    "types": ["jest", "node"],
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
- removed redundant `promise.resolve()` wrappers in a handful of functions
- added registerPageTargets() to the setScreen() function
- added deprecation warnings
- added conditional to `setupPage()` so that it respects the same logic as the `registerPageTargets()` function
- improved jest test suite
