### PR TITLE
[ENG-12064] Add `getIdentityId`, deprecate `getSessionID`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -169,7 +169,7 @@ dependencies {
   api 'com.facebook.react:react-android:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  implementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:4.2.0'
+  implementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:main'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -169,7 +169,7 @@ dependencies {
   api 'com.facebook.react:react-android:+'
 
   implementation 'androidx.core:core-ktx:1.8.0'
-  implementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:main'
+  implementation 'com.github.neuro-id.neuroid-android-sdk:react-android-sdk:main-SNAPSHOT'
 
   implementation 'com.google.code.gson:gson:2.10.1'
   implementation("androidx.lifecycle:lifecycle-process:2.3.0")

--- a/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/main/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -72,6 +72,14 @@ class NeuroidReactnativeSdkModuleImpl(
         }
     }
 
+    fun getIdentityId(promise: Promise) {
+        try {
+            promise.resolve(NeuroID.getInstance()?.getIdentityId())
+        } catch (e: Exception) {
+            promise.reject("ERR_GET_IDENTITY_ID", e.message)
+        }
+    }
+
     fun getSessionID(promise: Promise) {
         try {
             promise.resolve(NeuroID.getInstance()?.getSessionID())
@@ -85,6 +93,24 @@ class NeuroidReactnativeSdkModuleImpl(
             promise.resolve(NeuroID.getInstance()?.getUserID())
         } catch (e: Exception) {
             promise.reject("ERR_GET_USER_ID", e.message)
+        }
+    }
+
+    fun identify(sessionID: String, promise: Promise) {
+        try {
+            val result = NeuroID.getInstance()?.identify(sessionID)
+            promise.resolve(result ?: false)
+        } catch (e: Exception) {
+            promise.reject("ERR_IDENTIFY", e.message)
+        }
+    }
+
+    fun setUserID(id: String, promise: Promise) {
+        try {
+            val result = NeuroID.getInstance()?.setUserID(id)
+            promise.resolve(result ?: false)
+        } catch (e: Exception) {
+            promise.reject("ERR_SET_USER_ID", e.message)
         }
     }
 
@@ -111,24 +137,6 @@ class NeuroidReactnativeSdkModuleImpl(
             promise.resolve(result ?: false)
         } catch (e: Exception) {
             promise.reject("ERR_SET_SCREEN_NAME", e.message)
-        }
-    }
-
-    fun setUserID(id: String, promise: Promise) {
-        try {
-            val result = NeuroID.getInstance()?.setUserID(id)
-            promise.resolve(result ?: false)
-        } catch (e: Exception) {
-            promise.reject("ERR_SET_USER_ID", e.message)
-        }
-    }
-
-    fun identify(sessionID: String, promise: Promise) {
-        try {
-            val result = NeuroID.getInstance()?.identify(sessionID)
-            promise.resolve(result ?: false)
-        } catch (e: Exception) {
-            promise.reject("ERR_IDENTIFY", e.message)
         }
     }
 

--- a/android/src/newarch/java/com/neuroidreactnativesdk/NeuroReactnativeSdkModule.kt
+++ b/android/src/newarch/java/com/neuroidreactnativesdk/NeuroReactnativeSdkModule.kt
@@ -28,19 +28,21 @@ class NeuroidReactnativeSdkModule(
 
     override fun getScreenName(promise: Promise) = impl.getScreenName(promise)
 
+    override fun getIdentityId(promise: Promise) = impl.getIdentityId(promise)
+
     override fun getSessionID(promise: Promise) = impl.getSessionID(promise)
 
     override fun getUserID(promise: Promise) = impl.getUserID(promise)
+
+    override fun identify(sessionID: String, promise: Promise) = impl.identify(sessionID, promise)
+
+    override fun setUserID(id: String, promise: Promise) = impl.setUserID(id, promise)
 
     override fun getRegisteredUserID(promise: Promise) = impl.getRegisteredUserID(promise)
 
     override fun isStopped(promise: Promise) = impl.isStopped(promise)
 
     override fun setScreenName(screen: String, promise: Promise) = impl.setScreenName(screen, promise)
-
-    override fun setUserID(id: String, promise: Promise) = impl.setUserID(id, promise)
-
-    override fun identify(sessionID: String, promise: Promise) = impl.identify(sessionID, promise)
 
     override fun setRegisteredUserID(id: String, promise: Promise) =
         impl.setRegisteredUserID(id, promise)

--- a/android/src/oldarch/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
+++ b/android/src/oldarch/java/com/neuroidreactnativesdk/NeuroidReactnativeSdkModule.kt
@@ -35,10 +35,19 @@ class NeuroidReactnativeSdkModule(
     fun getScreenName(promise: Promise) = impl.getScreenName(promise)
 
     @ReactMethod
+    fun getIdentityId(promise: Promise) = impl.getIdentityId(promise)
+
+    @ReactMethod
     fun getSessionID(promise: Promise) = impl.getSessionID(promise)
 
     @ReactMethod
     fun getUserID(promise: Promise) = impl.getUserID(promise)
+
+    @ReactMethod
+    fun identify(sessionID: String, promise: Promise) = impl.identify(sessionID, promise)
+
+    @ReactMethod
+    fun setUserID(id: String, promise: Promise) = impl.setUserID(id, promise)
 
     @ReactMethod
     fun getRegisteredUserID(promise: Promise) = impl.getRegisteredUserID(promise)
@@ -48,12 +57,6 @@ class NeuroidReactnativeSdkModule(
 
     @ReactMethod
     fun setScreenName(screen: String, promise: Promise) = impl.setScreenName(screen, promise)
-
-    @ReactMethod
-    fun setUserID(id: String, promise: Promise) = impl.setUserID(id, promise)
-
-    @ReactMethod
-    fun identify(sessionID: String, promise: Promise) = impl.identify(sessionID, promise)
 
     @ReactMethod
     fun setRegisteredUserID(id: String, promise: Promise) =

--- a/ios/NeuroidReactnativeSdk.mm
+++ b/ios/NeuroidReactnativeSdk.mm
@@ -28,10 +28,21 @@ RCT_EXTERN_METHOD(getEnvironment:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(getScreenName:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getIdentityId:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getSessionID:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getUserID:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(identify:(NSString *)sessionID
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setUserID:(NSString *)userID
+                  resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getRegisteredUserID:(RCTPromiseResolveBlock)resolve
@@ -41,14 +52,6 @@ RCT_EXTERN_METHOD(isStopped:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setScreenName:(NSString *)screenName
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(setUserID:(NSString *)userID
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(identify:(NSString *)sessionID
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -146,7 +146,7 @@ class NeuroidReactnativeSdk: NSObject {
     @objc(startSession:resolve:reject:)
     func startSession(sessionID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         NeuroID.startSession(sessionID)  { result in
-            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+            let resultData: [String: Any] = ["identityId": result.identityId, "sessionID": result.sessionID, "started": result.started]
             resolve(resultData)
         }
     }
@@ -154,7 +154,7 @@ class NeuroidReactnativeSdk: NSObject {
     @objc(startAppFlow:userID:resolve:reject:)
     func startAppFlow(siteID: String, userID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         NeuroID.startAppFlow(siteID: siteID, sessionID: userID) { result in
-            let resultData: [String: Any] = ["sessionID": result.sessionID, "started": result.started]
+            let resultData: [String: Any] = ["identityId": result.identityId, "sessionID": result.sessionID, "started": result.started]
             resolve(resultData)
         }
     }

--- a/ios/NeuroidReactnativeSdk.swift
+++ b/ios/NeuroidReactnativeSdk.swift
@@ -40,6 +40,12 @@ class NeuroidReactnativeSdk: NSObject {
         resolve(screen)
     }
 
+    @objc(getIdentityId:reject:)
+    func getIdentityId(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        let identityId = NeuroID.getIdentityId()
+        resolve(identityId)
+    }
+
     @objc(getSessionID:reject:)
     func getSessionID(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let sid = NeuroID.getSessionID()
@@ -50,6 +56,18 @@ class NeuroidReactnativeSdk: NSObject {
     func getUserID(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let uid = NeuroID.getUserID()
         resolve(uid)
+    }
+
+    @objc(identify:resolve:reject:)
+    func identify(sessionID: String, resolve: RCTPromiseResolveBlock, _: RCTPromiseRejectBlock) {
+        let identifyResult = NeuroID.identify(sessionID)
+        resolve(identifyResult)
+    }
+
+    @objc(setUserID:resolve:reject:)
+    func setUserID(userID: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        let setResult = NeuroID.setUserID(userID)
+        resolve(setResult)
     }
 
     @objc(getRegisteredUserID:reject:)
@@ -68,18 +86,6 @@ class NeuroidReactnativeSdk: NSObject {
     func setScreenName(screenName: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let setResult = NeuroID.setScreenName(screenName)
         resolve(setResult)
-    }
-
-    @objc(setUserID:resolve:reject:)
-    func setUserID(userID: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let setResult = NeuroID.setUserID(userID)
-        resolve(setResult)
-    }
-
-    @objc(identify:resolve:reject:)
-    func identify(sessionID: String, resolve: RCTPromiseResolveBlock, _: RCTPromiseRejectBlock) {
-        let identifyResult = NeuroID.identify(sessionID)
-        resolve(identifyResult)
     }
 
     @objc(setRegisteredUserID:resolve:reject:)

--- a/src/NativeNeuroidReactnativeSdk.ts
+++ b/src/NativeNeuroidReactnativeSdk.ts
@@ -21,6 +21,7 @@ export interface NeuroIDLogClass {
 export interface SessionStartResult {
   started: boolean;
   sessionID: string;
+  identityId: string;
 }
 
 export interface Spec extends TurboModule {
@@ -49,9 +50,11 @@ export interface Spec extends TurboModule {
   stop(): Promise<boolean>;
   /** @deprecated Use setScreenName(sessionId) instead. */
   registerPageTargets(): Promise<void>;
-  startSession(
-    sessionID?: string
-  ): Promise<{ sessionID: string; started: boolean }>;
+  startSession(sessionID?: string): Promise<{
+    identityId: string;
+    sessionID: string;
+    started: boolean;
+  }>;
   stopSession(): Promise<boolean>;
   pauseCollection(): Promise<void>;
   resumeCollection(): Promise<void>;
@@ -59,7 +62,11 @@ export interface Spec extends TurboModule {
   startAppFlow(
     siteID: string,
     userID?: string
-  ): Promise<{ sessionID: string; started: boolean }>;
+  ): Promise<{
+    identityId: string;
+    sessionID: string;
+    started: boolean;
+  }>;
 }
 export interface NeuroIDClass extends Spec {
   /** @deprecated Use setScreenName(sessionId) instead. */

--- a/src/NativeNeuroidReactnativeSdk.ts
+++ b/src/NativeNeuroidReactnativeSdk.ts
@@ -30,15 +30,17 @@ export interface Spec extends TurboModule {
   getClientID(): Promise<string>;
   getEnvironment(): Promise<string>;
   getScreenName(): Promise<string>;
+  getIdentityId(): Promise<string>;
+  /** @deprecated Use getIdentityId() instead. */
   getSessionID(): Promise<string>;
-  /** @deprecated Use getSessionID() instead. */
+  /** @deprecated Use getIdentityId() instead. */
   getUserID(): Promise<string>;
+  identify(sessionID: string): Promise<boolean>;
+  /** @deprecated Use identify(sessionId) instead. */
+  setUserID(userID: string): Promise<boolean>;
   getRegisteredUserID(): Promise<string>;
   isStopped(): Promise<boolean>;
   setScreenName(screenName: string): Promise<boolean>;
-  /** @deprecated Use identify(sessionId) instead. */
-  setUserID(userID: string): Promise<boolean>;
-  identify(sessionID: string): Promise<boolean>;
   setRegisteredUserID(userID: string): Promise<boolean>;
   /** @deprecated */
   attemptedLogin(userID?: string): Promise<boolean>;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -10,13 +10,14 @@ type NativeSdkMock = {
   getClientID: jest.Mock<Promise<string>, []>;
   getEnvironment: jest.Mock<Promise<string>, []>;
   getScreenName: jest.Mock<Promise<string>, []>;
+  getIdentityId: jest.Mock<Promise<string>, []>;
   getSessionID: jest.Mock<Promise<string>, []>;
-  getRegisteredUserID: jest.Mock<Promise<string>, []>;
   getUserID: jest.Mock<Promise<string>, []>;
+  identify: jest.Mock<Promise<boolean>, [string]>;
+  setUserID: jest.Mock<unknown, [string]>;
+  getRegisteredUserID: jest.Mock<Promise<string>, []>;
   isStopped: jest.Mock<Promise<boolean>, []>;
   setScreenName: jest.Mock<Promise<boolean>, [string]>;
-  setUserID: jest.Mock<unknown, [string]>;
-  identify: jest.Mock<Promise<boolean>, [string]>;
   setRegisteredUserID: jest.Mock<unknown, [string]>;
   attemptedLogin: jest.Mock<unknown, [string?]>;
   setVariable: jest.Mock<Promise<void>, [string, string]>;
@@ -42,13 +43,14 @@ const mockNativeModule: NativeSdkMock = {
   getClientID: jest.fn().mockResolvedValue(""),
   getEnvironment: jest.fn().mockResolvedValue(""),
   getScreenName: jest.fn().mockResolvedValue(""),
+  getIdentityId: jest.fn().mockResolvedValue(""),
   getSessionID: jest.fn().mockResolvedValue(""),
-  getRegisteredUserID: jest.fn().mockResolvedValue(""),
   getUserID: jest.fn().mockResolvedValue(""),
+  identify: jest.fn().mockResolvedValue(true),
+  setUserID: jest.fn(),
+  getRegisteredUserID: jest.fn().mockResolvedValue(""),
   isStopped: jest.fn().mockResolvedValue(false),
   setScreenName: jest.fn().mockResolvedValue(true),
-  setUserID: jest.fn(),
-  identify: jest.fn().mockResolvedValue(true),
   setRegisteredUserID: jest.fn(),
   attemptedLogin: jest.fn(),
   setVariable: jest.fn().mockResolvedValue(undefined),
@@ -205,7 +207,7 @@ describe("NeuroID SDK", () => {
   describe("start", () => {
     it("resolves the native result when start succeeds", async () => {
       native.start!.mockResolvedValue(true);
-      native.getSessionID!.mockResolvedValue("sid-123");
+      native.getIdentityId!.mockResolvedValue("sid-123");
       const result = await NeuroID.start();
       expect(result).toBe(true);
       expect(native.start).toHaveBeenCalled();
@@ -359,6 +361,15 @@ describe("NeuroID SDK", () => {
     });
   });
 
+  // ── getIdentityId ────────────────────────────────────────────────────────────
+  describe("getIdentityId", () => {
+    it("resolves the value returned by native", async () => {
+      native.getIdentityId!.mockResolvedValue("session-xyz");
+      const result = await NeuroID.getIdentityId();
+      expect(result).toBe("session-xyz");
+    });
+  });
+
   // ── getSessionID ────────────────────────────────────────────────────────────
   describe("getSessionID", () => {
     it("resolves the value returned by native", async () => {
@@ -374,6 +385,34 @@ describe("NeuroID SDK", () => {
       native.getUserID!.mockResolvedValue("user-123");
       const result = await NeuroID.getUserID();
       expect(result).toBe("user-123");
+    });
+  });
+
+  // ── identify ───────────────────────────────────────────────────────────────
+  describe("identify", () => {
+    it("resolves true when native returns truthy", async () => {
+      native.identify!.mockResolvedValue(true);
+      await expect(NeuroID.identify("session-abc")).resolves.toBe(true);
+      expect(native.identify).toHaveBeenCalledWith("session-abc");
+    });
+
+    it("resolves false when native returns false", async () => {
+      native.identify!.mockResolvedValue(false);
+      await expect(NeuroID.identify("session-abc")).resolves.toBe(false);
+    });
+  });
+
+  // ── setUserID ───────────────────────────────────────────────────────────────
+  describe("setUserID", () => {
+    it("resolves true when native returns truthy", async () => {
+      native.setUserID!.mockReturnValue(true);
+      await expect(NeuroID.setUserID("user-abc")).resolves.toBe(true);
+      expect(native.setUserID).toHaveBeenCalledWith("user-abc");
+    });
+
+    it("rejects false when native returns falsy", async () => {
+      native.setUserID!.mockReturnValue(null);
+      await expect(NeuroID.setUserID("user-abc")).resolves.toBe(false);
     });
   });
 
@@ -424,34 +463,6 @@ describe("NeuroID SDK", () => {
       expect(native.setScreenName).toHaveBeenCalledWith("LoginScreen");
       expect(native.registerPageTargets).not.toHaveBeenCalled();
       expect(result).toBe(true);
-    });
-  });
-
-  // ── setUserID ───────────────────────────────────────────────────────────────
-  describe("setUserID", () => {
-    it("resolves true when native returns truthy", async () => {
-      native.setUserID!.mockReturnValue(true);
-      await expect(NeuroID.setUserID("user-abc")).resolves.toBe(true);
-      expect(native.setUserID).toHaveBeenCalledWith("user-abc");
-    });
-
-    it("rejects false when native returns falsy", async () => {
-      native.setUserID!.mockReturnValue(null);
-      await expect(NeuroID.setUserID("user-abc")).resolves.toBe(false);
-    });
-  });
-
-  // ── identify ───────────────────────────────────────────────────────────────
-  describe("identify", () => {
-    it("resolves true when native returns truthy", async () => {
-      native.identify!.mockResolvedValue(true);
-      await expect(NeuroID.identify("session-abc")).resolves.toBe(true);
-      expect(native.identify).toHaveBeenCalledWith("session-abc");
-    });
-
-    it("resolves false when native returns false", async () => {
-      native.identify!.mockResolvedValue(false);
-      await expect(NeuroID.identify("session-abc")).resolves.toBe(false);
     });
   });
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -25,14 +25,14 @@ type NativeSdkMock = {
   stop: jest.Mock<Promise<boolean>, []>;
   registerPageTargets: jest.Mock<Promise<void>, []>;
   startSession: jest.Mock<
-    Promise<{ sessionID: string; started: boolean }>,
+    Promise<{ identityId: string; sessionID: string; started: boolean }>,
     [string?]
   >;
   stopSession: jest.Mock<Promise<boolean>, []>;
   pauseCollection: jest.Mock<Promise<void>, []>;
   resumeCollection: jest.Mock<Promise<void>, []>;
   startAppFlow: jest.Mock<
-    Promise<{ sessionID: string; started: boolean }>,
+    Promise<{ identityId: string; sessionID: string; started: boolean }>,
     [string, string?]
   >;
 };
@@ -57,11 +57,15 @@ const mockNativeModule: NativeSdkMock = {
   start: jest.fn().mockResolvedValue(true),
   stop: jest.fn().mockResolvedValue(true),
   registerPageTargets: jest.fn().mockResolvedValue(undefined),
-  startSession: jest.fn().mockResolvedValue({ sessionID: "", started: true }),
+  startSession: jest
+    .fn()
+    .mockResolvedValue({ identityId: "", sessionID: "", started: true }),
   stopSession: jest.fn().mockResolvedValue(true),
   pauseCollection: jest.fn().mockResolvedValue(undefined),
   resumeCollection: jest.fn().mockResolvedValue(undefined),
-  startAppFlow: jest.fn().mockResolvedValue({ sessionID: "", started: true }),
+  startAppFlow: jest
+    .fn()
+    .mockResolvedValue({ identityId: "", sessionID: "", started: true }),
 };
 
 jest.mock("react-native", () => ({
@@ -479,15 +483,21 @@ describe("NeuroID SDK", () => {
   describe("startSession", () => {
     it("resolves a SessionStartResult with sessionID and started flag", async () => {
       native.startSession!.mockResolvedValue({
+        identityId: "sess-001",
         sessionID: "sess-001",
         started: true,
       });
       const result = await NeuroID.startSession();
-      expect(result).toEqual({ sessionID: "sess-001", started: true });
+      expect(result).toEqual({
+        identityId: "sess-001",
+        sessionID: "sess-001",
+        started: true,
+      });
     });
 
     it("passes an explicit sessionID to native when provided", async () => {
       native.startSession!.mockResolvedValue({
+        identityId: "custom-id",
         sessionID: "custom-id",
         started: true,
       });
@@ -533,16 +543,22 @@ describe("NeuroID SDK", () => {
   describe("startAppFlow", () => {
     it("resolves a SessionStartResult with siteID and optional userID", async () => {
       native.startAppFlow!.mockResolvedValue({
+        identityId: "app-sess-001",
         sessionID: "app-sess-001",
         started: true,
       });
       const result = await NeuroID.startAppFlow("site-xyz", "user-abc");
       expect(native.startAppFlow).toHaveBeenCalledWith("site-xyz", "user-abc");
-      expect(result).toEqual({ sessionID: "app-sess-001", started: true });
+      expect(result).toEqual({
+        identityId: "app-sess-001",
+        sessionID: "app-sess-001",
+        started: true,
+      });
     });
 
     it("works without an optional userID", async () => {
       native.startAppFlow!.mockResolvedValue({
+        identityId: "app-sess-002",
         sessionID: "app-sess-002",
         started: true,
       });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -125,6 +125,14 @@ export const NeuroID: NeuroIDClass = {
     });
   },
 
+  getIdentityId: function getIdentityId(): Promise<string> {
+    return NeuroidReactnativeSdk.getIdentityId().catch((error) => {
+      logNativeError("getIdentityId", error);
+      return "";
+    });
+  },
+
+  /** @deprecated Use getSessionId() instead. */
   getSessionID: function getSessionID(): Promise<string> {
     return NeuroidReactnativeSdk.getSessionID().catch((error) => {
       logNativeError("getSessionID", error);
@@ -143,27 +151,10 @@ export const NeuroID: NeuroIDClass = {
     });
   },
 
-  getRegisteredUserID: function getUserID(): Promise<string> {
-    return NeuroidReactnativeSdk.getRegisteredUserID().catch((error) => {
-      logNativeError("getRegisteredUserID", error);
-      return "";
-    });
-  },
-
-  isStopped: function isStopped(): Promise<boolean> {
-    return NeuroidReactnativeSdk.isStopped().catch((error) => {
-      logNativeError("isStopped", error);
-      return true;
-    });
-  },
-
-  setScreenName: function setScreenName(screenName: string): Promise<boolean> {
-    NeuroIDLog.d("setScreenName()", screenName);
-    registerPageTargetsInternal().catch((err) => {
-      NeuroIDLog.e("registerPageTargets failed", err);
-    });
-    return NeuroidReactnativeSdk.setScreenName(screenName).catch((error) => {
-      logNativeError("setScreenName", error);
+  identify: function identify(sessionID: string): Promise<boolean> {
+    NeuroIDLog.i("Identify : ", sessionID);
+    return NeuroidReactnativeSdk.identify(sessionID).catch((error) => {
+      logNativeError("identify", error);
       return false;
     });
   },
@@ -187,10 +178,27 @@ export const NeuroID: NeuroIDClass = {
     }
   },
 
-  identify: function identify(sessionID: string): Promise<boolean> {
-    NeuroIDLog.i("Identify : ", sessionID);
-    return NeuroidReactnativeSdk.identify(sessionID).catch((error) => {
-      logNativeError("identify", error);
+  getRegisteredUserID: function getUserID(): Promise<string> {
+    return NeuroidReactnativeSdk.getRegisteredUserID().catch((error) => {
+      logNativeError("getRegisteredUserID", error);
+      return "";
+    });
+  },
+
+  isStopped: function isStopped(): Promise<boolean> {
+    return NeuroidReactnativeSdk.isStopped().catch((error) => {
+      logNativeError("isStopped", error);
+      return true;
+    });
+  },
+
+  setScreenName: function setScreenName(screenName: string): Promise<boolean> {
+    NeuroIDLog.d("setScreenName()", screenName);
+    registerPageTargetsInternal().catch((err) => {
+      NeuroIDLog.e("registerPageTargets failed", err);
+    });
+    return NeuroidReactnativeSdk.setScreenName(screenName).catch((error) => {
+      logNativeError("setScreenName", error);
       return false;
     });
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -310,12 +310,14 @@ export const NeuroID: NeuroIDClass = {
         "startSession(): " + result.sessionID + " " + result.started
       );
       return {
+        identityId: result.identityId,
         sessionID: result.sessionID,
         started: result.started,
       };
     } catch (error) {
       logNativeError("startSession", error);
       return {
+        identityId: "",
         sessionID: "",
         started: false,
       };
@@ -369,12 +371,14 @@ export const NeuroID: NeuroIDClass = {
         "startAppFlow(): " + result.sessionID + " " + result.started
       );
       return {
+        identityId: result.identityId,
         sessionID: result.sessionID,
         started: result.started,
       };
     } catch (error) {
       logNativeError("startAppFlow", error);
       return {
+        identityId: "",
         sessionID: "",
         started: false,
       };

--- a/tests/SmokeRunner.ts
+++ b/tests/SmokeRunner.ts
@@ -51,7 +51,7 @@ export async function runSmoke(): Promise<void> {
     { name: "startSession", run: () => NeuroID.startSession() },
     { name: "setScreenName", run: () => NeuroID.setScreenName("TestScreen") },
     { name: "getScreenName", run: () => NeuroID.getScreenName() },
-    { name: "getSessionID", run: () => NeuroID.getSessionID() },
+    { name: "getIdentityId", run: () => NeuroID.getIdentityId() },
     { name: "registerPageTargets", run: () => NeuroID.registerPageTargets() }, // NOSONAR: intentional deprecated API smoke coverage
     { name: "setupPage", run: () => NeuroID.setupPage("SetupPageScreen") }, // NOSONAR: intentional deprecated API smoke coverage
     { name: "isStopped", run: () => !NeuroID.isStopped() },


### PR DESCRIPTION
Replaces occurrences of "Session ID" with "Identity ID". Adds `getIdentityId` and deprecates `getSessionID`. This aligns the getters and setters with trackjs as well.

[ENG-12064]


[ENG-12064]: https://neuro-id.atlassian.net/browse/ENG-12064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ