### PR TITLE
ENG-12099-brace-expansion update

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   "overrides": {
     "@babel/core": "7.29.6",
     "glob": "^9.3.5",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.2.0",
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
Update brace-expansion to version 5.0.9 via npm overrides to address security/compatibility requirements.